### PR TITLE
Simplify the PEG.

### DIFF
--- a/crates/wac-parser/src/ast.rs
+++ b/crates/wac-parser/src/ast.rs
@@ -113,8 +113,8 @@ struct EndOfInput;
 #[derive(Debug, Clone, FromPest)]
 #[pest_ast(rule(Rule::Document))]
 pub struct Document<'a> {
-    /// The statements in the document.
-    pub statements: Vec<Statement<'a>>,
+    /// The top-level statements in the document.
+    pub statements: Vec<TopLevelStatement<'a>>,
     _eoi: EndOfInput,
 }
 
@@ -208,32 +208,32 @@ impl AstDisplay for Document<'_> {
 
 display!(Document);
 
-/// Represents a statement in the AST.
+/// Represents a top-level statement in the AST.
 #[derive(Debug, Clone, FromPest)]
-#[pest_ast(rule(Rule::Statement))]
-pub struct Statement<'a> {
+#[pest_ast(rule(Rule::TopLevelStatement))]
+pub struct TopLevelStatement<'a> {
     /// The doc comments for the statement.
     pub docs: Vec<DocComment<'a>>,
-    /// The statement kind.
-    pub kind: StatementKind<'a>,
+    /// The statement.
+    pub stmt: Statement<'a>,
 }
 
-impl AstDisplay for Statement<'_> {
+impl AstDisplay for TopLevelStatement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, indenter: &mut Indenter) -> fmt::Result {
         for doc in &self.docs {
             doc.fmt(f, indenter)?;
         }
 
-        self.kind.fmt(f, indenter)
+        self.stmt.fmt(f, indenter)
     }
 }
 
-display!(Statement);
+display!(TopLevelStatement);
 
-/// Represents a statement kind in the AST.
+/// Represents a statement in the AST.
 #[derive(Debug, Clone, FromPest)]
-#[pest_ast(rule(Rule::StatementKind))]
-pub enum StatementKind<'a> {
+#[pest_ast(rule(Rule::Statement))]
+pub enum Statement<'a> {
     /// An import statement.
     Import(ImportStatement<'a>),
     /// A type statement.
@@ -244,7 +244,7 @@ pub enum StatementKind<'a> {
     Export(ExportStatement<'a>),
 }
 
-impl AstDisplay for StatementKind<'_> {
+impl AstDisplay for Statement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, indenter: &mut Indenter) -> fmt::Result {
         match self {
             Self::Import(import) => import.fmt(f, indenter),
@@ -255,7 +255,7 @@ impl AstDisplay for StatementKind<'_> {
     }
 }
 
-display!(StatementKind);
+display!(Statement);
 
 /// Represents an identifier in the AST.
 #[derive(Debug, Clone, FromPest)]

--- a/crates/wac-parser/src/ast/type.rs
+++ b/crates/wac-parser/src/ast/type.rs
@@ -1014,8 +1014,8 @@ display!(InterfaceBody);
 pub struct InterfaceItem<'a> {
     /// The doc comments for the interface item.
     pub docs: Vec<DocComment<'a>>,
-    /// The interface item kind.
-    pub kind: InterfaceItemKind<'a>,
+    /// The interface item statement.
+    pub stmt: InterfaceItemStatement<'a>,
 }
 
 impl AstDisplay for InterfaceItem<'_> {
@@ -1024,16 +1024,16 @@ impl AstDisplay for InterfaceItem<'_> {
             doc.fmt(f, indenter)?;
         }
 
-        self.kind.fmt(f, indenter)
+        self.stmt.fmt(f, indenter)
     }
 }
 
 display!(InterfaceItem);
 
-/// Represents an interface item kind in the AST.
+/// Represents an interface item statement in the AST.
 #[derive(Debug, Clone, FromPest)]
-#[pest_ast(rule(Rule::InterfaceItemKind))]
-pub enum InterfaceItemKind<'a> {
+#[pest_ast(rule(Rule::InterfaceItemStatement))]
+pub enum InterfaceItemStatement<'a> {
     /// The item is a use statement.
     Use(Box<UseStatement<'a>>),
     /// The item is a value type statement.
@@ -1042,7 +1042,7 @@ pub enum InterfaceItemKind<'a> {
     Export(InterfaceExportStatement<'a>),
 }
 
-impl AstDisplay for InterfaceItemKind<'_> {
+impl AstDisplay for InterfaceItemStatement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, indenter: &mut Indenter) -> fmt::Result {
         match self {
             Self::Use(u) => u.fmt(f, indenter),
@@ -1052,7 +1052,7 @@ impl AstDisplay for InterfaceItemKind<'_> {
     }
 }
 
-display!(InterfaceItemKind);
+display!(InterfaceItemStatement);
 
 /// Represents a use statement in the AST.
 #[derive(Debug, Clone, FromPest)]
@@ -1219,8 +1219,8 @@ display!(WorldBody);
 pub struct WorldItem<'a> {
     /// The doc comments for the world item.
     pub docs: Vec<DocComment<'a>>,
-    /// The world item kind.
-    pub kind: WorldItemKind<'a>,
+    /// The world item statement.
+    pub stmt: WorldItemStatement<'a>,
 }
 
 impl AstDisplay for WorldItem<'_> {
@@ -1229,16 +1229,16 @@ impl AstDisplay for WorldItem<'_> {
             doc.fmt(f, indenter)?;
         }
 
-        self.kind.fmt(f, indenter)
+        self.stmt.fmt(f, indenter)
     }
 }
 
 display!(WorldItem);
 
-/// Represents a world item kind in the AST.
+/// Represents a world item statement in the AST.
 #[derive(Debug, Clone, FromPest)]
-#[pest_ast(rule(Rule::WorldItemKind))]
-pub enum WorldItemKind<'a> {
+#[pest_ast(rule(Rule::WorldItemStatement))]
+pub enum WorldItemStatement<'a> {
     /// The item is a use statement.
     Use(Box<UseStatement<'a>>),
     /// The item is a value type statement.
@@ -1251,7 +1251,7 @@ pub enum WorldItemKind<'a> {
     Include(WorldIncludeStatement<'a>),
 }
 
-impl AstDisplay for WorldItemKind<'_> {
+impl AstDisplay for WorldItemStatement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, indenter: &mut Indenter) -> fmt::Result {
         match self {
             Self::Use(u) => u.fmt(f, indenter),
@@ -1263,7 +1263,7 @@ impl AstDisplay for WorldItemKind<'_> {
     }
 }
 
-display!(WorldItemKind);
+display!(WorldItemStatement);
 
 /// Represents a world import statement in the AST.
 #[derive(Debug, Clone, FromPest)]

--- a/crates/wac-parser/src/parser.rs
+++ b/crates/wac-parser/src/parser.rs
@@ -21,7 +21,7 @@ mod pest {
                 Self::LineComment => "line comment",
                 Self::BlockComment => "block comment",
 
-                Self::Document | Self::Statement | Self::StatementKind => "statement",
+                Self::Document | Self::TopLevelStatement | Self::Statement => "statement",
                 Self::ImportStatement => "import statement",
                 Self::TypeStatement => "type statement",
                 Self::ValueTypeStatement => "value type statement",
@@ -74,12 +74,12 @@ mod pest {
 
                 Self::InterfaceBody => "interface body",
                 Self::InterfaceItem => "interface item",
-                Self::InterfaceItemKind => "interface item kind",
+                Self::InterfaceItemStatement => "interface item statement",
                 Self::InterfaceExportStatement => "interface export statement",
 
                 Self::WorldBody => "world body",
                 Self::WorldItem => "world item",
-                Self::WorldItemKind => "world item kind",
+                Self::WorldItemStatement => "world item statement",
                 Self::WorldImportStatement => "world import statement",
                 Self::WorldExportStatement => "world export statement",
                 Self::WorldItemDecl => "world item declaration",

--- a/crates/wac-parser/wac.pest
+++ b/crates/wac-parser/wac.pest
@@ -1,9 +1,9 @@
 // Top-level document rule
-Document = { SOI ~ Statement* ~ EOI }
+Document = { SOI ~ TopLevelStatement* ~ EOI }
 
 // Top-level statements
-Statement     = ${ DocComment* ~ WHITESPACE* ~ StatementKind }
-StatementKind = !{ ImportStatement | TypeStatement | LetStatement | ExportStatement }
+TopLevelStatement = { DocComment* ~ Statement }
+Statement         = { ImportStatement | TypeStatement | LetStatement | ExportStatement }
 
 // Import statement
 ImportStatement = ${ ImportKeyword ~ DelimitingSpace+ ~ Ident ~ (DelimitingSpace+ ~ WithClause)? ~ DelimitingSpace* ~ Colon ~ DelimitingSpace* ~ ImportType ~ DelimitingSpace* ~ Semicolon }
@@ -14,32 +14,57 @@ PackageName     = ${ Ident ~ (":" ~ Ident)+ }
 PackageVersion  =  { (ASCII_ALPHANUMERIC | "." | "-" | "+")+ }
 
 // Type statement
-TypeStatement            = !{ InterfaceDecl | WorldDecl | ValueTypeStatement }
-ValueTypeStatement       =  { ResourceDecl | VariantDecl | RecordDecl | FlagsDecl | EnumDecl | TypeAlias }
-ResourceDecl             = ${ ResourceKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ ResourceBody }
-ResourceBody             = !{ Semicolon | (OpenBrace ~ (ResourceMethod ~ Semicolon)+ ~ CloseBrace) }
-VariantDecl              = ${ VariantKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ VariantBody }
-VariantBody              = !{ OpenBrace ~ VariantCase ~ ("," ~ VariantCase)* ~ ","? ~ CloseBrace }
-VariantCase              =  { Ident ~ VariantType? }
-VariantType              =  { OpenParen ~ Type ~ CloseParen }
-RecordDecl               = ${ RecordKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ RecordBody }
-RecordBody               = !{ OpenBrace ~ NamedType ~ ("," ~ NamedType)* ~ ","? ~ CloseBrace }
-FlagsDecl                = ${ FlagsKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ FlagsBody }
-FlagsBody                = !{ OpenBrace ~ Ident ~ ("," ~ Ident)* ~ ","? ~ CloseBrace }
-EnumDecl                 = ${ EnumKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ EnumBody }
-EnumBody                 = !{ OpenBrace ~ Ident ~ ("," ~ Ident)* ~ ","? ~ CloseBrace }
-TypeAlias                = ${ TypeKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ Equals ~ DelimitingSpace* ~ TypeAliasKind ~ DelimitingSpace* ~ Semicolon }
-TypeAliasKind            = !{ FuncType | Type }
-ResourceMethod           =  { Constructor | Method }
-Constructor              =  { ConstructorKeyword ~ ParamList }
-Method                   =  { Ident ~ Colon ~ StaticKeyword? ~ FuncTypeRef }
-FuncTypeRef              =  { Ident | FuncType }
-FuncType                 =  { FuncKeyword ~ ParamList ~ ResultList? }
-ParamList                =  { OpenParen ~ (NamedType ~ ("," ~ NamedType)* ~ ","?)? ~ CloseParen }
-ResultList               =  { Arrow ~ (NamedResultList | Type) }
-NamedResultList          =  { OpenParen ~ (NamedType ~ ("," ~ NamedType)* ~ ","?)? ~ CloseParen }
-NamedType                =  { Ident ~ Colon ~ Type }
-Type                     =  {
+TypeStatement            =  { InterfaceDecl | WorldDecl | ValueTypeStatement }
+InterfaceDecl            = ${ InterfaceKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ InterfaceBody }
+InterfaceBody            = !{ OpenBrace ~ InterfaceItem* ~ CloseBrace }
+InterfaceItem            =  { DocComment* ~ InterfaceItemStatement }
+InterfaceItemStatement   =  { UseStatement | ValueTypeStatement | InterfaceExportStatement }
+UseStatement             = ${ UseKeyword ~ DelimitingSpace+ ~ UseItems ~ DelimitingSpace* ~ Semicolon }
+UseItems                 = !{ UsePath ~ Dot ~ OpenBrace ~ Ident ~ ("," ~ Ident)* ~ ","? ~ CloseBrace }
+UsePath                  =  { PackagePath | Ident }
+InterfaceExportStatement =  { Ident ~ Colon ~ FuncTypeRef ~ Semicolon }
+WorldDecl                = ${ WorldKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ WorldBody }
+WorldBody                = !{ OpenBrace ~ WorldItem* ~ CloseBrace }
+WorldItem                =  { DocComment* ~ WorldItemStatement }
+WorldItemStatement       =  { UseStatement | ValueTypeStatement | WorldImportStatement | WorldExportStatement | WorldIncludeStatement }
+WorldImportStatement     = ${ ImportKeyword ~ DelimitingSpace+ ~ WorldItemDecl ~ DelimitingSpace* ~ Semicolon }
+WorldExportStatement     = ${ ExportKeyword ~ DelimitingSpace+ ~ WorldItemDecl ~ DelimitingSpace* ~ Semicolon }
+WorldItemDecl            = !{ WorldNamedItem | InterfaceRef }
+WorldNamedItem           =  { Ident ~ Colon ~ ExternType ~ !Slash }
+InterfaceRef             =  { PackagePath | Ident }
+ExternType               =  { FuncType | InlineInterface | Ident }
+InlineInterface          =  { InterfaceKeyword ~ InterfaceBody }
+WorldIncludeStatement    = ${ IncludeKeyword ~ DelimitingSpace+ ~ WorldRef ~ DelimitingSpace* ~ WorldIncludeWithClause? ~ DelimitingSpace* ~ Semicolon }
+WorldIncludeWithClause   = !{ WithKeyword ~ OpenBrace ~ WorldIncludeItem ~ ("," ~ WorldIncludeItem)* ~ ","? ~ CloseBrace }
+WorldIncludeItem         = ${ Ident ~ DelimitingSpace+ ~ AsKeyword ~ DelimitingSpace+ ~ Ident }
+WorldRef                 =  { PackagePath | Ident }
+
+// Value type statement
+ValueTypeStatement =  { ResourceDecl | VariantDecl | RecordDecl | FlagsDecl | EnumDecl | TypeAlias }
+ResourceDecl       = ${ ResourceKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ ResourceBody }
+ResourceBody       = !{ Semicolon | (OpenBrace ~ (ResourceMethod ~ Semicolon)+ ~ CloseBrace) }
+ResourceMethod     =  { Constructor | Method }
+Constructor        =  { ConstructorKeyword ~ ParamList }
+Method             =  { Ident ~ Colon ~ StaticKeyword? ~ FuncTypeRef }
+VariantDecl        = ${ VariantKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ VariantBody }
+VariantBody        = !{ OpenBrace ~ VariantCase ~ ("," ~ VariantCase)* ~ ","? ~ CloseBrace }
+VariantCase        =  { Ident ~ VariantType? }
+VariantType        =  { OpenParen ~ Type ~ CloseParen }
+RecordDecl         = ${ RecordKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ RecordBody }
+RecordBody         = !{ OpenBrace ~ NamedType ~ ("," ~ NamedType)* ~ ","? ~ CloseBrace }
+FlagsDecl          = ${ FlagsKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ FlagsBody }
+FlagsBody          = !{ OpenBrace ~ Ident ~ ("," ~ Ident)* ~ ","? ~ CloseBrace }
+EnumDecl           = ${ EnumKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ EnumBody }
+EnumBody           = !{ OpenBrace ~ Ident ~ ("," ~ Ident)* ~ ","? ~ CloseBrace }
+TypeAlias          = ${ TypeKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ Equals ~ DelimitingSpace* ~ TypeAliasKind ~ DelimitingSpace* ~ Semicolon }
+TypeAliasKind      = !{ FuncType | Type }
+FuncTypeRef        =  { FuncType | Ident }
+FuncType           =  { FuncKeyword ~ ParamList ~ ResultList? }
+ParamList          =  { OpenParen ~ (NamedType ~ ("," ~ NamedType)* ~ ","?)? ~ CloseParen }
+ResultList         =  { Arrow ~ (NamedResultList | Type) }
+NamedResultList    =  { OpenParen ~ (NamedType ~ ("," ~ NamedType)* ~ ","?)? ~ CloseParen }
+NamedType          =  { Ident ~ Colon ~ Type }
+Type               =  {
     U8Keyword
   | S8Keyword
   | U16Keyword
@@ -60,34 +85,13 @@ Type                     =  {
   | Borrow
   | Ident
 }
-Tuple                    =  { TupleKeyword ~ OpenAngle ~ Type ~ ("," ~ Type)* ~ CloseAngle }
-List                     =  { ListKeyword ~ OpenAngle ~ Type ~ CloseAngle }
-Option                   =  { OptionKeyword ~ OpenAngle ~ Type ~ CloseAngle }
-Result                   =  { ResultKeyword ~ SpecifiedResult? }
-SpecifiedResult          =  { OpenAngle ~ OmitType ~ ("," ~ Type)? ~ CloseAngle }
-OmitType                 =  { Underscore | Type }
-Borrow                   =  { BorrowKeyword ~ OpenAngle ~ Ident ~ CloseAngle }
-InterfaceDecl            = ${ InterfaceKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ InterfaceBody }
-InterfaceBody            = !{ OpenBrace ~ InterfaceItem* ~ CloseBrace }
-InterfaceItem            = ${ DocComment* ~ WHITESPACE* ~ InterfaceItemKind }
-InterfaceItemKind        = !{ UseStatement | ValueTypeStatement | InterfaceExportStatement }
-InterfaceExportStatement =  { Ident ~ Colon ~ FuncTypeRef ~ Semicolon }
-WorldDecl            = ${ WorldKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ WorldBody }
-WorldBody            = !{ OpenBrace ~ WorldItem* ~ CloseBrace }
-WorldItem            = ${ DocComment* ~ WHITESPACE* ~ WorldItemKind }
-WorldItemKind        = !{ UseStatement | ValueTypeStatement | WorldImportStatement | WorldExportStatement | WorldIncludeStatement }
-WorldImportStatement = ${ ImportKeyword ~ DelimitingSpace+ ~ WorldItemDecl ~ DelimitingSpace* ~ Semicolon }
-WorldExportStatement = ${ ExportKeyword ~ DelimitingSpace+ ~ WorldItemDecl ~ DelimitingSpace* ~ Semicolon }
-WorldItemDecl        = !{ WorldNamedItem | InterfaceRef }
-WorldNamedItem       = ${ Ident ~ DelimitingSpace* ~ Colon ~ DelimitingSpace+ ~ ExternType }
-InterfaceRef         =  { PackagePath | Ident }
-ExternType           = !{ FuncType | InlineInterface | Ident }
-InlineInterface      =  { InterfaceKeyword ~ InterfaceBody }
-
-WorldIncludeStatement  = ${ IncludeKeyword ~ DelimitingSpace+ ~ WorldRef ~ DelimitingSpace* ~ WorldIncludeWithClause? ~ DelimitingSpace* ~ Semicolon }
-WorldIncludeWithClause = !{ WithKeyword ~ OpenBrace ~ WorldIncludeItem ~ ("," ~ WorldIncludeItem)* ~ ","? ~ CloseBrace }
-WorldIncludeItem       = ${ Ident ~ DelimitingSpace+ ~ AsKeyword ~ DelimitingSpace+ ~ Ident }
-WorldRef               = { PackagePath | Ident }
+Tuple              =  { TupleKeyword ~ OpenAngle ~ Type ~ ("," ~ Type)* ~ CloseAngle }
+List               =  { ListKeyword ~ OpenAngle ~ Type ~ CloseAngle }
+Option             =  { OptionKeyword ~ OpenAngle ~ Type ~ CloseAngle }
+Result             =  { ResultKeyword ~ SpecifiedResult? }
+SpecifiedResult    =  { OpenAngle ~ OmitType ~ ("," ~ Type)? ~ CloseAngle }
+OmitType           =  { Underscore | Type }
+Borrow             =  { BorrowKeyword ~ OpenAngle ~ Ident ~ CloseAngle }
 
 // Let statement
 LetStatement = ${ LetKeyword ~ DelimitingSpace+ ~ Ident ~ DelimitingSpace* ~ Equals ~ DelimitingSpace* ~ Expr ~ DelimitingSpace* ~ Semicolon }
@@ -108,11 +112,6 @@ NestedExpr                 =  { OpenParen ~ Expr ~ CloseParen }
 PostfixExpr                =  { AccessExpr | NamedAccessExpr }
 AccessExpr                 = ${ Dot ~ Ident }
 NamedAccessExpr            =  { OpenBracket ~ String ~ CloseBracket }
-
-// Use statement in interface and world definitinos
-UseStatement = ${ UseKeyword ~ DelimitingSpace+ ~ UseItems ~ DelimitingSpace* ~ Semicolon }
-UseItems     = !{ UsePath ~ Dot ~ OpenBrace ~ Ident ~ ("," ~ Ident)* ~ ","? ~ CloseBrace }
-UsePath      =  { PackagePath | Ident }
 
 // Identifiers
 RawIdent  = _{ Percent ~ IdentPart ~ (Hyphen ~ IdentPart)* }


### PR DESCRIPTION
This PR simplifies the PEG a little:

* Make some rules non-atomic where applicable.
* Shuffle the rule definitions to better group related rules.
* Rename some rules to be more descriptive.