### PR TITLE
Implement export statement resolution. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstream",
  "anstyle",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -312,9 +312,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -352,9 +352,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -559,9 +559,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags",
  "errno",
@@ -590,18 +590,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.191"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "a834c4821019838224821468552240d4d95d14e751986442c816572d39a080c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.191"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "46fa52d5646bce91b680189fe5b1c049d2ea38dabb4e2e7c8d00ca12cfbfbcfd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -769,7 +769,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "wasmparser 0.115.0",
+ "wasmparser",
  "wat",
  "wit-component",
  "wit-parser",
@@ -777,18 +777,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae0be20bf87918df4fa831bfbbd0b491d24aee407ed86360eae4c2c5608d38"
+checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.10"
+version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5621910462c61a8efc3248fdfb1739bf649bb335b0df935c27b340418105f9d8"
+checksum = "2167ce53b2faa16a92c6cafd4942cff16c9a4fa0c5a5a0a41131ee4e49fc055f"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -797,24 +797,14 @@ dependencies = [
  "serde_json",
  "spdx",
  "wasm-encoder",
- "wasmparser 0.116.0",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.115.0"
+version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
-dependencies = [
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.116.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53290b1276c5c2d47d694fb1a920538c01f51690e7e261acbe1d10c5fc306ea1"
+checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
  "indexmap",
  "semver",
@@ -822,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "67.0.0"
+version = "67.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c2933efd77ff2398b83817a98984ffe4b67aefd9aa1d2c8e68e19b553f1c38"
+checksum = "a974d82fac092b5227c1663e16514e7a85f32014e22e6fdcb08b71aec9d3fb1e"
 dependencies = [
  "leb128",
  "memchr",
@@ -834,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02905d13751dcb18f4e19f489d37a1bf139f519feaeef28d072a41a78e69a74"
+checksum = "adb220934f92f8551144c0003d1bc57a060674c99139f45ed623fbbf6d9262e7"
 dependencies = [
  "wast",
 ]
@@ -940,9 +930,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "wit-component"
-version = "0.16.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65672b7a81f9c7a4420af2ad8d0de608e27b520a6d4b68f29f5146e060a86ee4"
+checksum = "634d0371ac5e57e42991aa53f0d79e53e53484afbf54777a5347605b0b229b9d"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -953,15 +943,15 @@ dependencies = [
  "serde_json",
  "wasm-encoder",
  "wasm-metadata",
- "wasmparser 0.116.0",
+ "wasmparser",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ace9943d89bbf3dbbc71b966da0e7302057b311f36a4ac3d65ddfef17b52cf"
+checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,20 +35,20 @@ wat = ["wac-parser/wat"]
 
 [workspace.dependencies]
 wac-parser = { path = "crates/wac-parser", default-features = false }
-wit-parser = "0.12.1"
-wasmparser = "0.115.0"
-wit-component = "0.16.0"
+wit-parser = "0.13.0"
+wasmparser = "0.116.1"
+wit-component = "0.18.0"
 anyhow = "1.0.75"
-clap = { version = "4.4.6", features = ["derive"] }
+clap = { version = "4.4.7", features = ["derive"] }
 semver = "1.0.20"
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
 tokio = { version = "1.33.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
-indexmap = { version = "2.0.2", features = ["serde"] }
+indexmap = { version = "2.1.0", features = ["serde"] }
 id-arena = "2.2.1"
-serde = { version = "1.0.189", features = ["derive"] }
-serde_json = "1.0.107"
-wat = "1.0.77"
+serde = { version = "1.0.191", features = ["derive"] }
+serde_json = "1.0.108"
+wat = "1.0.79"
 logos = "0.13.0"
 thiserror = "1.0.50"

--- a/crates/wac-parser/src/ast/export.rs
+++ b/crates/wac-parser/src/ast/export.rs
@@ -2,7 +2,7 @@ use super::{
     display, expr::Expr, parse_optional, parse_token, DocComment, Lookahead, Parse, ParseResult,
     Peek,
 };
-use crate::lexer::{Lexer, Token};
+use crate::lexer::{Lexer, Span, Token};
 use serde::Serialize;
 
 /// Represents an export statement in the AST.
@@ -11,6 +11,8 @@ use serde::Serialize;
 pub struct ExportStatement<'a> {
     /// The doc comments for the statement.
     pub docs: Vec<DocComment<'a>>,
+    /// The span of the export keyword.
+    pub span: Span<'a>,
     /// The optional `with` string.
     pub with: Option<super::String<'a>>,
     /// The expression to export.
@@ -20,11 +22,16 @@ pub struct ExportStatement<'a> {
 impl<'a> Parse<'a> for ExportStatement<'a> {
     fn parse(lexer: &mut Lexer<'a>) -> ParseResult<'a, Self> {
         let docs = Parse::parse(lexer)?;
-        parse_token(lexer, Token::ExportKeyword)?;
+        let span = parse_token(lexer, Token::ExportKeyword)?;
         let expr = Parse::parse(lexer)?;
         let with = parse_optional(lexer, Token::WithKeyword, Parse::parse)?;
         parse_token(lexer, Token::Semicolon)?;
-        Ok(Self { docs, expr, with })
+        Ok(Self {
+            docs,
+            span,
+            expr,
+            with,
+        })
     }
 }
 

--- a/crates/wac-parser/src/resolution/types.rs
+++ b/crates/wac-parser/src/resolution/types.rs
@@ -525,7 +525,7 @@ impl fmt::Display for CoreRefType {
         let s = match (self.nullable, self.heap_type) {
             (true, HeapType::Func) => "funcref",
             (true, HeapType::Extern) => "externref",
-            (true, HeapType::Indexed(i)) => return write!(f, "(ref null {i})"),
+            (true, HeapType::Concrete(i)) => return write!(f, "(ref null {i})"),
             (true, HeapType::Any) => "anyref",
             (true, HeapType::None) => "nullref",
             (true, HeapType::NoExtern) => "nullexternref",
@@ -536,7 +536,7 @@ impl fmt::Display for CoreRefType {
             (true, HeapType::I31) => "i31ref",
             (false, HeapType::Func) => "(ref func)",
             (false, HeapType::Extern) => "(ref extern)",
-            (false, HeapType::Indexed(i)) => return write!(f, "(ref {i})"),
+            (false, HeapType::Concrete(i)) => return write!(f, "(ref {i})"),
             (false, HeapType::Any) => "(ref any)",
             (false, HeapType::None) => "(ref none)",
             (false, HeapType::NoExtern) => "(ref noextern)",
@@ -564,7 +564,7 @@ impl From<wasmparser::RefType> for CoreRefType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum HeapType {
     /// User defined type at the given index.
-    Indexed(u32),
+    Concrete(u32),
     /// Untyped (any) function.
     Func,
     /// External heap type.
@@ -600,7 +600,7 @@ impl From<wasmparser::HeapType> for HeapType {
             wasmparser::HeapType::NoFunc => Self::NoFunc,
             wasmparser::HeapType::Struct => Self::Struct,
             wasmparser::HeapType::Array => Self::Array,
-            wasmparser::HeapType::Indexed(index) => Self::Indexed(index),
+            wasmparser::HeapType::Concrete(index) => Self::Concrete(index),
         }
     }
 }

--- a/crates/wac-parser/tests/parser/export.wac.result
+++ b/crates/wac-parser/tests/parser/export.wac.result
@@ -12,6 +12,11 @@
             }
           }
         ],
+        "span": {
+          "str": "export",
+          "start": 34,
+          "end": 40
+        },
         "with": null,
         "expr": {
           "primary": {
@@ -40,6 +45,11 @@
             }
           }
         ],
+        "span": {
+          "str": "export",
+          "start": 91,
+          "end": 97
+        },
         "with": null,
         "expr": {
           "primary": {
@@ -86,6 +96,11 @@
             }
           }
         ],
+        "span": {
+          "str": "export",
+          "start": 162,
+          "end": 168
+        },
         "with": {
           "value": "bar",
           "span": {

--- a/crates/wac-parser/tests/resolution/alias.wac
+++ b/crates/wac-parser/tests/resolution/alias.wac
@@ -3,3 +3,7 @@ type a = u32;
 type b = string;
 
 type c = func();
+
+export a with "a2";
+export b with "b2";
+export c with "c2";

--- a/crates/wac-parser/tests/resolution/alias.wac.result
+++ b/crates/wac-parser/tests/resolution/alias.wac.result
@@ -46,6 +46,12 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {
+    "a2": 0,
+    "b2": 1,
+    "c2": 2
+  },
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/duplicate-world-item.wac.result
+++ b/crates/wac-parser/tests/resolution/duplicate-world-item.wac.result
@@ -45,6 +45,8 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {},
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac
@@ -1,0 +1,5 @@
+import f with "x": func();
+
+type x = u32;
+
+export f;

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac.result
@@ -1,0 +1,5 @@
+export `x` conflicts with u32 definition at tests/resolution/fail/export-conflict-alias.wac:3:6 (consider using a `with` clause to use a different name)
+    --> tests/resolution/fail/export-conflict-alias.wac:5:1
+     |
+   5 | export f;
+     | ^----^

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac
@@ -1,0 +1,7 @@
+import f: func();
+
+interface foo {
+
+}
+
+export f with "foo";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac.result
@@ -1,0 +1,5 @@
+export `foo` conflicts with interface definition at tests/resolution/fail/export-conflict-interface.wac:3:11
+    --> tests/resolution/fail/export-conflict-interface.wac:7:15
+     |
+   7 | export f with "foo";
+     |               ^---^

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac
@@ -1,0 +1,7 @@
+import f with "x": func();
+
+record x {
+    a: u32
+}
+
+export f with "x";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac.result
@@ -1,0 +1,5 @@
+export `x` conflicts with record definition at tests/resolution/fail/export-conflict-type.wac:3:8
+    --> tests/resolution/fail/export-conflict-type.wac:7:15
+     |
+   7 | export f with "x";
+     |               ^-^

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac
@@ -1,0 +1,7 @@
+import f: func();
+
+world foo {
+
+}
+
+export f with "foo";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac.result
@@ -1,0 +1,5 @@
+export `foo` conflicts with world definition at tests/resolution/fail/export-conflict-world.wac:3:7
+    --> tests/resolution/fail/export-conflict-world.wac:7:15
+     |
+   7 | export f with "foo";
+     |               ^---^

--- a/crates/wac-parser/tests/resolution/fail/export-dep-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-dep-name.wac
@@ -1,0 +1,2 @@
+import f: func();
+export f with "locked-dep=<foo:bar>";

--- a/crates/wac-parser/tests/resolution/fail/export-dep-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-dep-name.wac.result
@@ -1,0 +1,8 @@
+export name `locked-dep=<foo:bar>` is not valid
+    --> tests/resolution/fail/export-dep-name.wac:2:15
+     |
+   2 | export f with "locked-dep=<foo:bar>";
+     |               ^--------------------^
+
+Caused by:
+    export name cannot be a hash, url, or dependency

--- a/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac
@@ -1,0 +1,3 @@
+import f: func();
+export f with "x";
+export f with "x";

--- a/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac.result
@@ -1,0 +1,5 @@
+duplicate export `x`
+    --> tests/resolution/fail/export-duplicate-name.wac:3:15
+     |
+   3 | export f with "x";
+     |               ^-^

--- a/crates/wac-parser/tests/resolution/fail/export-hash-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-hash-name.wac
@@ -1,0 +1,2 @@
+import f: func();
+export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";

--- a/crates/wac-parser/tests/resolution/fail/export-hash-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-hash-name.wac.result
@@ -1,0 +1,8 @@
+export name `integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>` is not valid
+    --> tests/resolution/fail/export-hash-name.wac:2:15
+     |
+   2 | export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";
+     |               ^-----------------------------------------------------------------------------------^
+
+Caused by:
+    export name cannot be a hash, url, or dependency

--- a/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac
@@ -1,0 +1,2 @@
+import f: func();
+export f with "INVALID!";

--- a/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac.result
@@ -1,0 +1,8 @@
+export name `INVALID!` is not valid
+    --> tests/resolution/fail/export-invalid-name.wac:2:15
+     |
+   2 | export f with "INVALID!";
+     |               ^--------^
+
+Caused by:
+    `INVALID!` is not in kebab case

--- a/crates/wac-parser/tests/resolution/fail/export-needs-with.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-needs-with.wac
@@ -1,3 +1,2 @@
 let i = new foo:bar {};
-
-export i with "i";
+export i;

--- a/crates/wac-parser/tests/resolution/fail/export-needs-with.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-needs-with.wac.result
@@ -1,0 +1,5 @@
+export statement requires a `with` clause as the export name cannot be inferred
+    --> tests/resolution/fail/export-needs-with.wac:2:1
+     |
+   2 | export i;
+     | ^----^

--- a/crates/wac-parser/tests/resolution/fail/export-needs-with/foo/bar.wat
+++ b/crates/wac-parser/tests/resolution/fail/export-needs-with/foo/bar.wat
@@ -1,0 +1,1 @@
+(component)

--- a/crates/wac-parser/tests/resolution/fail/export-url-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-url-name.wac
@@ -1,0 +1,2 @@
+import f: func();
+export f with "url=<https://example.com/foo>";

--- a/crates/wac-parser/tests/resolution/fail/export-url-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-url-name.wac.result
@@ -1,0 +1,8 @@
+export name `url=<https://example.com/foo>` is not valid
+    --> tests/resolution/fail/export-url-name.wac:2:15
+     |
+   2 | export f with "url=<https://example.com/foo>";
+     |               ^-----------------------------^
+
+Caused by:
+    export name cannot be a hash, url, or dependency

--- a/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac
@@ -1,0 +1,2 @@
+import x with "foo": func();
+import y with "foo": interface {};

--- a/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac.result
@@ -1,0 +1,5 @@
+duplicate import `foo`
+    --> tests/resolution/fail/import-duplicate-name.wac:2:15
+     |
+   2 | import y with "foo": interface {};
+     |               ^---^

--- a/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac
@@ -1,0 +1,1 @@
+import x with "NOT-VALID-NAME!": func();

--- a/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac.result
@@ -1,0 +1,8 @@
+import name `NOT-VALID-NAME!` is not valid
+    --> tests/resolution/fail/import-invalid-name.wac:1:15
+     |
+   1 | import x with "NOT-VALID-NAME!": func();
+     |               ^---------------^
+
+Caused by:
+    `NOT-VALID-NAME!` is not in kebab case

--- a/crates/wac-parser/tests/resolution/import.wac
+++ b/crates/wac-parser/tests/resolution/import.wac
@@ -18,3 +18,7 @@ import e: interface {
 
 /// Import by package path with version
 import f: foo:bar/baz@1.0.0;
+
+export d;
+export e with "e";
+export f;

--- a/crates/wac-parser/tests/resolution/import.wac.result
+++ b/crates/wac-parser/tests/resolution/import.wac.result
@@ -75,9 +75,7 @@
         "func": 0
       },
       "source": {
-        "import": {
-          "with": null
-        }
+        "import": "a"
       }
     },
     {
@@ -93,9 +91,7 @@
         "func": 1
       },
       "source": {
-        "import": {
-          "with": null
-        }
+        "import": "b"
       }
     },
     {
@@ -103,9 +99,7 @@
         "func": 2
       },
       "source": {
-        "import": {
-          "with": "hello-world"
-        }
+        "import": "hello-world"
       }
     },
     {
@@ -113,9 +107,7 @@
         "instance": 0
       },
       "source": {
-        "import": {
-          "with": null
-        }
+        "import": "e"
       }
     },
     {
@@ -123,12 +115,22 @@
         "instance": 1
       },
       "source": {
-        "import": {
-          "with": null
-        }
+        "import": "foo:bar/baz"
       }
     }
   ],
+  "imports": {
+    "a": 0,
+    "b": 2,
+    "hello-world": 3,
+    "e": 4,
+    "foo:bar/baz": 5
+  },
+  "exports": {
+    "hello-world": 3,
+    "e": 4,
+    "foo:bar/baz": 5
+  },
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/let-statements.wac
+++ b/crates/wac-parser/tests/resolution/let-statements.wac
@@ -1,3 +1,6 @@
 import streams: wasi:io/streams;
 
 let i = new foo:bar { streams, baz: new foo:bar { streams, ... }.baz };
+
+export i.baz;
+export i with "i";

--- a/crates/wac-parser/tests/resolution/let-statements.wac.result
+++ b/crates/wac-parser/tests/resolution/let-statements.wac.result
@@ -422,9 +422,7 @@
         "instance": 0
       },
       "source": {
-        "import": {
-          "with": null
-        }
+        "import": "wasi:io/streams@0.2.0-rc-2023-10-18"
       }
     },
     {
@@ -462,8 +460,26 @@
           }
         }
       }
+    },
+    {
+      "kind": {
+        "instance": 2
+      },
+      "source": {
+        "alias": {
+          "item": 3,
+          "export": "foo:bar/baz@0.1.0"
+        }
+      }
     }
   ],
+  "imports": {
+    "wasi:io/streams@0.2.0-rc-2023-10-18": 0
+  },
+  "exports": {
+    "foo:bar/baz@0.1.0": 4,
+    "i": 3
+  },
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/no-imports.wac.result
+++ b/crates/wac-parser/tests/resolution/no-imports.wac.result
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "imports": {},
+  "exports": {
+    "i": 0
+  },
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/package-import.wac
+++ b/crates/wac-parser/tests/resolution/package-import.wac
@@ -1,1 +1,3 @@
 import i: foo:bar/i;
+
+export i;

--- a/crates/wac-parser/tests/resolution/package-import.wac.result
+++ b/crates/wac-parser/tests/resolution/package-import.wac.result
@@ -97,12 +97,16 @@
         "instance": 0
       },
       "source": {
-        "import": {
-          "with": null
-        }
+        "import": "foo:bar/i"
       }
     }
   ],
+  "imports": {
+    "foo:bar/i": 0
+  },
+  "exports": {
+    "foo:bar/i": 0
+  },
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/package-use-item.wac.result
+++ b/crates/wac-parser/tests/resolution/package-use-item.wac.result
@@ -260,6 +260,8 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {},
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/package-world-include.wac.result
+++ b/crates/wac-parser/tests/resolution/package-world-include.wac.result
@@ -157,6 +157,8 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {},
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/package-world-item.wac.result
+++ b/crates/wac-parser/tests/resolution/package-world-item.wac.result
@@ -141,6 +141,8 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {},
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/resource.wac.result
+++ b/crates/wac-parser/tests/resolution/resource.wac.result
@@ -76,6 +76,8 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {},
   "scopes": [
     {
       "parent": null,

--- a/crates/wac-parser/tests/resolution/types.wac.result
+++ b/crates/wac-parser/tests/resolution/types.wac.result
@@ -519,6 +519,8 @@
       "source": "definition"
     }
   ],
+  "imports": {},
+  "exports": {},
   "scopes": [
     {
       "parent": null,


### PR DESCRIPTION
This PR completes AST resolution.

An `imports` and `exports` collection were added to the resolution to keep
track of imported and exported items from the composition.

The resolution now ensures that import names are unique.

Additionally, this updates to the latest dependencies including changes to
`wasmparser`'s type information representation.

Import and export names are now validated in accordance with the latest
component model spec; this will enable specifying import dependencies when
performing encodings.