### PR TITLE
Add a package declaration to the grammar. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,9 @@ name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ wasmparser = "0.116.1"
 wit-component = "0.18.0"
 anyhow = "1.0.75"
 clap = { version = "4.4.7", features = ["derive"] }
-semver = "1.0.20"
+semver = { version = "1.0.20", features = ["serde"] }
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
 tokio = { version = "1.33.0", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 The current WAC grammar:
 
 ```ebnf
-document  ::= statement*
-statement ::= import-statement 
+document  ::= package-decl statement*
+statement ::= import-statement
             | type-statement
             | let-statement
             | export-statement
 
+package-decl ::= `package` package-name `;`
+package-name ::= id (':' id)+ ('@' version)?
+version      ::= <SEMVER>
+
 import-statement ::= 'import' id ('with' string)? ':' import-type ';'
 import-type      ::= package-path | func-type | inline-interface | id
-package-path     ::= package-name ('/' id)+ ('@' package-version)?
-package-name     ::= id (':' id)+
-package-version  ::= <SEMVER>
+package-path     ::= id (':' id)+ ('/' id)+ ('@' version)?
 
 type-statement      ::= interface-decl | world-decl | type-decl
 interface-decl      ::= 'interface' id '{' interface-item* '}'

--- a/crates/wac-parser/src/lexer.rs
+++ b/crates/wac-parser/src/lexer.rs
@@ -148,7 +148,7 @@ fn detect_invalid_input(source: &str) -> Result<(), (Error, Span)> {
 #[logos(skip r"[ \t\n\f]+")]
 #[logos(subpattern id = r"%?[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*")]
 #[logos(subpattern package_name = r"(?&id)(:(?&id))+")]
-#[logos(subpattern semver = r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?")]
+#[logos(subpattern semver = r"[0-9a-zA-Z-\.\+]+")]
 pub enum Token {
     /// A comment.
     #[regex(r"//[^\n]*", logos::skip)]
@@ -167,7 +167,7 @@ pub enum Token {
     String,
 
     /// A package name.
-    #[regex(r"(?&id)(:(?&id))+")]
+    #[regex(r"(?&package_name)(@(?&semver))?")]
     PackageName,
 
     /// A package path with optional semantic version.
@@ -285,6 +285,9 @@ pub enum Token {
     /// The `as` keyword.
     #[token("as")]
     AsKeyword,
+    /// The `package` keyword.
+    #[token("package")]
+    PackageKeyword,
 
     /// The `;` symbol.
     #[token(";")]
@@ -387,6 +390,7 @@ impl fmt::Display for Token {
             Token::UseKeyword => write!(f, "`use` keyword"),
             Token::IncludeKeyword => write!(f, "`include` keyword"),
             Token::AsKeyword => write!(f, "`as` keyword"),
+            Token::PackageKeyword => write!(f, "`package` keyword"),
             Token::Semicolon => write!(f, "`;`"),
             Token::OpenBrace => write!(f, "`{{`"),
             Token::CloseBrace => write!(f, "`}}`"),

--- a/crates/wac-parser/src/printer.rs
+++ b/crates/wac-parser/src/printer.rs
@@ -27,6 +27,14 @@ impl<W: Write> DocumentPrinter<W> {
 
     /// Prints the given document.
     pub fn document(&mut self, doc: &Document) -> std::fmt::Result {
+        self.docs(&doc.docs)?;
+        writeln!(
+            self.writer,
+            "package {package};",
+            package = doc.package.span.as_str()
+        )?;
+        self.newline()?;
+
         for (i, statement) in doc.statements.iter().enumerate() {
             if i > 0 {
                 self.newline()?;

--- a/crates/wac-parser/tests/parser/export.wac
+++ b/crates/wac-parser/tests/parser/export.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 /// Export an item (default name)
 export e;
 

--- a/crates/wac-parser/tests/parser/export.wac.result
+++ b/crates/wac-parser/tests/parser/export.wac.result
@@ -1,4 +1,14 @@
 {
+  "docs": [],
+  "package": {
+    "name": "test:comp",
+    "version": null,
+    "span": {
+      "str": "test:comp",
+      "start": 8,
+      "end": 17
+    }
+  },
   "statements": [
     {
       "Export": {
@@ -7,15 +17,15 @@
             "comment": "Export an item (default name)",
             "span": {
               "str": "/// Export an item (default name)",
-              "start": 0,
-              "end": 33
+              "start": 20,
+              "end": 53
             }
           }
         ],
         "span": {
           "str": "export",
-          "start": 34,
-          "end": 40
+          "start": 54,
+          "end": 60
         },
         "with": null,
         "expr": {
@@ -24,8 +34,8 @@
               "string": "e",
               "span": {
                 "str": "e",
-                "start": 41,
-                "end": 42
+                "start": 61,
+                "end": 62
               }
             }
           },
@@ -40,15 +50,15 @@
             "comment": "Export an alias of an item (default name)",
             "span": {
               "str": "/// Export an alias of an item (default name)",
-              "start": 45,
-              "end": 90
+              "start": 65,
+              "end": 110
             }
           }
         ],
         "span": {
           "str": "export",
-          "start": 91,
-          "end": 97
+          "start": 111,
+          "end": 117
         },
         "with": null,
         "expr": {
@@ -57,8 +67,8 @@
               "string": "e",
               "span": {
                 "str": "e",
-                "start": 98,
-                "end": 99
+                "start": 118,
+                "end": 119
               }
             }
           },
@@ -67,15 +77,15 @@
               "namedAccess": {
                 "span": {
                   "str": "[\"foo\"]",
-                  "start": 99,
-                  "end": 106
+                  "start": 119,
+                  "end": 126
                 },
                 "string": {
                   "value": "foo",
                   "span": {
                     "str": "\"foo\"",
-                    "start": 100,
-                    "end": 105
+                    "start": 120,
+                    "end": 125
                   }
                 }
               }
@@ -91,22 +101,22 @@
             "comment": "Export an alias of an item with a different name",
             "span": {
               "str": "/// Export an alias of an item with a different name",
-              "start": 109,
-              "end": 161
+              "start": 129,
+              "end": 181
             }
           }
         ],
         "span": {
           "str": "export",
-          "start": 162,
-          "end": 168
+          "start": 182,
+          "end": 188
         },
         "with": {
           "value": "bar",
           "span": {
             "str": "\"bar\"",
-            "start": 183,
-            "end": 188
+            "start": 203,
+            "end": 208
           }
         },
         "expr": {
@@ -115,8 +125,8 @@
               "string": "e",
               "span": {
                 "str": "e",
-                "start": 169,
-                "end": 170
+                "start": 189,
+                "end": 190
               }
             }
           },
@@ -125,15 +135,15 @@
               "namedAccess": {
                 "span": {
                   "str": "[\"foo\"]",
-                  "start": 170,
-                  "end": 177
+                  "start": 190,
+                  "end": 197
                 },
                 "string": {
                   "value": "foo",
                   "span": {
                     "str": "\"foo\"",
-                    "start": 171,
-                    "end": 176
+                    "start": 191,
+                    "end": 196
                   }
                 }
               }

--- a/crates/wac-parser/tests/parser/fail/bad-alias.wac
+++ b/crates/wac-parser/tests/parser/fail/bad-alias.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 type u32 = x;

--- a/crates/wac-parser/tests/parser/fail/bad-alias.wac.result
+++ b/crates/wac-parser/tests/parser/fail/bad-alias.wac.result
@@ -1,5 +1,5 @@
 expected identifier, found `u32` keyword
-    --> tests/parser/fail/bad-alias.wac:1:6
+    --> tests/parser/fail/bad-alias.wac:3:6
      |
-   1 | type u32 = x;
+   3 | type u32 = x;
      |      ^-^

--- a/crates/wac-parser/tests/parser/fail/duplicate-package-decl.wac
+++ b/crates/wac-parser/tests/parser/fail/duplicate-package-decl.wac
@@ -1,0 +1,2 @@
+package test:comp;
+package test:comp;

--- a/crates/wac-parser/tests/parser/fail/duplicate-package-decl.wac.result
+++ b/crates/wac-parser/tests/parser/fail/duplicate-package-decl.wac.result
@@ -1,0 +1,5 @@
+expected either `import` keyword, `let` keyword, `export` keyword, `interface` keyword, `world` keyword, `variant` keyword, `record` keyword, `flags` keyword, `enum` keyword, or `type` keyword, found `package` keyword
+    --> tests/parser/fail/duplicate-package-decl.wac:2:1
+     |
+   2 | package test:comp;
+     | ^-----^

--- a/crates/wac-parser/tests/parser/fail/empty-enum.wac
+++ b/crates/wac-parser/tests/parser/fail/empty-enum.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 enum e {}

--- a/crates/wac-parser/tests/parser/fail/empty-enum.wac.result
+++ b/crates/wac-parser/tests/parser/fail/empty-enum.wac.result
@@ -1,5 +1,5 @@
 enum must contain at least one case
-    --> tests/parser/fail/empty-enum.wac:1:9
+    --> tests/parser/fail/empty-enum.wac:3:9
      |
-   1 | enum e {}
+   3 | enum e {}
      |         ^

--- a/crates/wac-parser/tests/parser/fail/empty-flags.wac
+++ b/crates/wac-parser/tests/parser/fail/empty-flags.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 flags f {}

--- a/crates/wac-parser/tests/parser/fail/empty-flags.wac.result
+++ b/crates/wac-parser/tests/parser/fail/empty-flags.wac.result
@@ -1,5 +1,5 @@
 flags must contain at least one flag
-    --> tests/parser/fail/empty-flags.wac:1:10
+    --> tests/parser/fail/empty-flags.wac:3:10
      |
-   1 | flags f {}
+   3 | flags f {}
      |          ^

--- a/crates/wac-parser/tests/parser/fail/empty-record.wac
+++ b/crates/wac-parser/tests/parser/fail/empty-record.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 record r {}

--- a/crates/wac-parser/tests/parser/fail/empty-record.wac.result
+++ b/crates/wac-parser/tests/parser/fail/empty-record.wac.result
@@ -1,5 +1,5 @@
 record must contain at least one field
-    --> tests/parser/fail/empty-record.wac:1:11
+    --> tests/parser/fail/empty-record.wac:3:11
      |
-   1 | record r {}
+   3 | record r {}
      |           ^

--- a/crates/wac-parser/tests/parser/fail/empty-variant.wac
+++ b/crates/wac-parser/tests/parser/fail/empty-variant.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 variant v {}

--- a/crates/wac-parser/tests/parser/fail/empty-variant.wac.result
+++ b/crates/wac-parser/tests/parser/fail/empty-variant.wac.result
@@ -1,5 +1,5 @@
 variant must contain at least one case
-    --> tests/parser/fail/empty-variant.wac:1:12
+    --> tests/parser/fail/empty-variant.wac:3:12
      |
-   1 | variant v {}
+   3 | variant v {}
      |            ^

--- a/crates/wac-parser/tests/parser/fail/expected-multiple.wac
+++ b/crates/wac-parser/tests/parser/fail/expected-multiple.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 type x = 

--- a/crates/wac-parser/tests/parser/fail/expected-multiple.wac.result
+++ b/crates/wac-parser/tests/parser/fail/expected-multiple.wac.result
@@ -1,5 +1,5 @@
 expected either `func` keyword, `u8` keyword, `s8` keyword, `u16` keyword, `s16` keyword, `u32` keyword, `s32` keyword, `u64` keyword, `s64` keyword, `float32` keyword, or more..., found end of input
-    --> tests/parser/fail/expected-multiple.wac:1:10
+    --> tests/parser/fail/expected-multiple.wac:3:10
      |
-   1 | type x = 
+   3 | type x = 
      |          ^

--- a/crates/wac-parser/tests/parser/fail/expected-two.wac
+++ b/crates/wac-parser/tests/parser/fail/expected-two.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 record foo {

--- a/crates/wac-parser/tests/parser/fail/expected-two.wac.result
+++ b/crates/wac-parser/tests/parser/fail/expected-two.wac.result
@@ -1,5 +1,5 @@
 expected `}` or identifier, found end of input
-    --> tests/parser/fail/expected-two.wac:2:1
+    --> tests/parser/fail/expected-two.wac:4:1
      |
-   2 | 
+   4 | 
      | ^

--- a/crates/wac-parser/tests/parser/fail/invalid-path-semver.wac
+++ b/crates/wac-parser/tests/parser/fail/invalid-path-semver.wac
@@ -1,0 +1,3 @@
+package foo:bar;
+
+import i: foo:bar/baz@1;

--- a/crates/wac-parser/tests/parser/fail/invalid-path-semver.wac.result
+++ b/crates/wac-parser/tests/parser/fail/invalid-path-semver.wac.result
@@ -1,0 +1,5 @@
+`1` is not a valid semantic version
+    --> tests/parser/fail/invalid-path-semver.wac:3:23
+     |
+   3 | import i: foo:bar/baz@1;
+     |                       ^

--- a/crates/wac-parser/tests/parser/fail/invalid-semver.wac
+++ b/crates/wac-parser/tests/parser/fail/invalid-semver.wac
@@ -1,0 +1,1 @@
+package foo:bar@1;

--- a/crates/wac-parser/tests/parser/fail/invalid-semver.wac.result
+++ b/crates/wac-parser/tests/parser/fail/invalid-semver.wac.result
@@ -1,0 +1,5 @@
+`1` is not a valid semantic version
+    --> tests/parser/fail/invalid-semver.wac:1:17
+     |
+   1 | package foo:bar@1;
+     |                 ^

--- a/crates/wac-parser/tests/parser/fail/missing-package-decl.wac
+++ b/crates/wac-parser/tests/parser/fail/missing-package-decl.wac
@@ -1,0 +1,1 @@
+import f: func();

--- a/crates/wac-parser/tests/parser/fail/missing-package-decl.wac.result
+++ b/crates/wac-parser/tests/parser/fail/missing-package-decl.wac.result
@@ -1,0 +1,5 @@
+expected `package` keyword, found `import` keyword
+    --> tests/parser/fail/missing-package-decl.wac:1:1
+     |
+   1 | import f: func();
+     | ^----^

--- a/crates/wac-parser/tests/parser/fail/missing-semi.wac
+++ b/crates/wac-parser/tests/parser/fail/missing-semi.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 type x = u32

--- a/crates/wac-parser/tests/parser/fail/missing-semi.wac.result
+++ b/crates/wac-parser/tests/parser/fail/missing-semi.wac.result
@@ -1,5 +1,5 @@
 expected `;`, found end of input
-    --> tests/parser/fail/missing-semi.wac:1:13
+    --> tests/parser/fail/missing-semi.wac:3:13
      |
-   1 | type x = u32
+   3 | type x = u32
      |             ^

--- a/crates/wac-parser/tests/parser/import.wac
+++ b/crates/wac-parser/tests/parser/import.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 /// Import by func type
 import a: func();
 

--- a/crates/wac-parser/tests/parser/import.wac.result
+++ b/crates/wac-parser/tests/parser/import.wac.result
@@ -1,4 +1,14 @@
 {
+  "docs": [],
+  "package": {
+    "name": "test:comp",
+    "version": null,
+    "span": {
+      "str": "test:comp",
+      "start": 8,
+      "end": 17
+    }
+  },
   "statements": [
     {
       "Import": {
@@ -7,8 +17,8 @@
             "comment": "Import by func type",
             "span": {
               "str": "/// Import by func type",
-              "start": 0,
-              "end": 23
+              "start": 20,
+              "end": 43
             }
           }
         ],
@@ -16,8 +26,8 @@
           "string": "a",
           "span": {
             "str": "a",
-            "start": 31,
-            "end": 32
+            "start": 51,
+            "end": 52
           }
         },
         "with": null,
@@ -36,8 +46,8 @@
             "comment": "Import by ident",
             "span": {
               "str": "/// Import by ident",
-              "start": 43,
-              "end": 62
+              "start": 63,
+              "end": 82
             }
           }
         ],
@@ -45,8 +55,8 @@
           "string": "b",
           "span": {
             "str": "b",
-            "start": 70,
-            "end": 71
+            "start": 90,
+            "end": 91
           }
         },
         "with": null,
@@ -55,8 +65,8 @@
             "string": "x",
             "span": {
               "str": "x",
-              "start": 73,
-              "end": 74
+              "start": 93,
+              "end": 94
             }
           }
         }
@@ -69,8 +79,8 @@
             "comment": "Import by package path",
             "span": {
               "str": "/// Import by package path",
-              "start": 77,
-              "end": 103
+              "start": 97,
+              "end": 123
             }
           }
         ],
@@ -78,8 +88,8 @@
           "string": "c",
           "span": {
             "str": "c",
-            "start": 111,
-            "end": 112
+            "start": 131,
+            "end": 132
           }
         },
         "with": null,
@@ -87,8 +97,8 @@
           "package": {
             "span": {
               "str": "foo:bar/baz",
-              "start": 114,
-              "end": 125
+              "start": 134,
+              "end": 145
             },
             "name": "foo:bar",
             "segments": "baz",
@@ -104,8 +114,8 @@
             "comment": "Import by func type with kebab name",
             "span": {
               "str": "/// Import by func type with kebab name ",
-              "start": 128,
-              "end": 168
+              "start": 148,
+              "end": 188
             }
           }
         ],
@@ -113,16 +123,16 @@
           "string": "d",
           "span": {
             "str": "d",
-            "start": 176,
-            "end": 177
+            "start": 196,
+            "end": 197
           }
         },
         "with": {
           "value": "hello-world",
           "span": {
             "str": "\"hello-world\"",
-            "start": 183,
-            "end": 196
+            "start": 203,
+            "end": 216
           }
         },
         "ty": {
@@ -133,8 +143,8 @@
                   "string": "name",
                   "span": {
                     "str": "name",
-                    "start": 203,
-                    "end": 207
+                    "start": 223,
+                    "end": 227
                   }
                 },
                 "ty": "string"
@@ -152,8 +162,8 @@
             "comment": "Import by inline interface",
             "span": {
               "str": "/// Import by inline interface",
-              "start": 219,
-              "end": 249
+              "start": 239,
+              "end": 269
             }
           }
         ],
@@ -161,8 +171,8 @@
           "string": "e",
           "span": {
             "str": "e",
-            "start": 257,
-            "end": 258
+            "start": 277,
+            "end": 278
           }
         },
         "with": null,
@@ -176,8 +186,8 @@
                     "string": "x",
                     "span": {
                       "str": "x",
-                      "start": 276,
-                      "end": 277
+                      "start": 296,
+                      "end": 297
                     }
                   },
                   "ty": {
@@ -200,8 +210,8 @@
             "comment": "Import by package path with version",
             "span": {
               "str": "/// Import by package path with version",
-              "start": 291,
-              "end": 330
+              "start": 311,
+              "end": 350
             }
           }
         ],
@@ -209,8 +219,8 @@
           "string": "f",
           "span": {
             "str": "f",
-            "start": 338,
-            "end": 339
+            "start": 358,
+            "end": 359
           }
         },
         "with": null,
@@ -218,8 +228,8 @@
           "package": {
             "span": {
               "str": "foo:bar/baz@1.0.0",
-              "start": 341,
-              "end": 358
+              "start": 361,
+              "end": 378
             },
             "name": "foo:bar",
             "segments": "baz",

--- a/crates/wac-parser/tests/parser/let.wac
+++ b/crates/wac-parser/tests/parser/let.wac
@@ -1,14 +1,16 @@
+package test:comp;
+
 /// Instantiate without args
 let a = new foo:bar {};
 
 /// Instantiation with import-propagation.
-let b = new foo:bar { ... };
+let b = new foo:bar@1.0.0 { ... };
 
 /// Instantiation with arguments
-let c = new foo:bar { a, b, "c": c, };
+let c = new foo:bar@2.0.0 { a, b, "c": c, };
 
 /// Instantiation with arguments and import-propagation.
-let d = new foo:bar { a, "b": (new foo:bar { }), c: c, ... };
+let d = new foo:bar@3.0.0 { a, "b": (new foo:bar { }), c: c, ... };
 
 /// Nested expression
 let e = (b);

--- a/crates/wac-parser/tests/parser/let.wac.result
+++ b/crates/wac-parser/tests/parser/let.wac.result
@@ -1,4 +1,14 @@
 {
+  "docs": [],
+  "package": {
+    "name": "test:comp",
+    "version": null,
+    "span": {
+      "str": "test:comp",
+      "start": 8,
+      "end": 17
+    }
+  },
   "statements": [
     {
       "Let": {
@@ -7,8 +17,8 @@
             "comment": "Instantiate without args",
             "span": {
               "str": "/// Instantiate without args",
-              "start": 0,
-              "end": 28
+              "start": 20,
+              "end": 48
             }
           }
         ],
@@ -16,8 +26,8 @@
           "string": "a",
           "span": {
             "str": "a",
-            "start": 33,
-            "end": 34
+            "start": 53,
+            "end": 54
           }
         },
         "expr": {
@@ -25,10 +35,11 @@
             "new": {
               "package": {
                 "name": "foo:bar",
+                "version": null,
                 "span": {
                   "str": "foo:bar",
-                  "start": 41,
-                  "end": 48
+                  "start": 61,
+                  "end": 68
                 }
               },
               "arguments": [],
@@ -46,8 +57,8 @@
             "comment": "Instantiation with import-propagation.",
             "span": {
               "str": "/// Instantiation with import-propagation.",
-              "start": 54,
-              "end": 96
+              "start": 74,
+              "end": 116
             }
           }
         ],
@@ -55,8 +66,8 @@
           "string": "b",
           "span": {
             "str": "b",
-            "start": 101,
-            "end": 102
+            "start": 121,
+            "end": 122
           }
         },
         "expr": {
@@ -64,10 +75,11 @@
             "new": {
               "package": {
                 "name": "foo:bar",
+                "version": "1.0.0",
                 "span": {
-                  "str": "foo:bar",
-                  "start": 109,
-                  "end": 116
+                  "str": "foo:bar@1.0.0",
+                  "start": 129,
+                  "end": 142
                 }
               },
               "arguments": [],
@@ -85,8 +97,8 @@
             "comment": "Instantiation with arguments",
             "span": {
               "str": "/// Instantiation with arguments",
-              "start": 127,
-              "end": 159
+              "start": 153,
+              "end": 185
             }
           }
         ],
@@ -94,8 +106,8 @@
           "string": "c",
           "span": {
             "str": "c",
-            "start": 164,
-            "end": 165
+            "start": 190,
+            "end": 191
           }
         },
         "expr": {
@@ -103,10 +115,11 @@
             "new": {
               "package": {
                 "name": "foo:bar",
+                "version": "2.0.0",
                 "span": {
-                  "str": "foo:bar",
-                  "start": 172,
-                  "end": 179
+                  "str": "foo:bar@2.0.0",
+                  "start": 198,
+                  "end": 211
                 }
               },
               "arguments": [
@@ -115,8 +128,8 @@
                     "string": "a",
                     "span": {
                       "str": "a",
-                      "start": 182,
-                      "end": 183
+                      "start": 214,
+                      "end": 215
                     }
                   }
                 },
@@ -125,8 +138,8 @@
                     "string": "b",
                     "span": {
                       "str": "b",
-                      "start": 185,
-                      "end": 186
+                      "start": 217,
+                      "end": 218
                     }
                   }
                 },
@@ -137,8 +150,8 @@
                         "value": "c",
                         "span": {
                           "str": "\"c\"",
-                          "start": 188,
-                          "end": 191
+                          "start": 220,
+                          "end": 223
                         }
                       }
                     },
@@ -148,8 +161,8 @@
                           "string": "c",
                           "span": {
                             "str": "c",
-                            "start": 193,
-                            "end": 194
+                            "start": 225,
+                            "end": 226
                           }
                         }
                       },
@@ -172,8 +185,8 @@
             "comment": "Instantiation with arguments and import-propagation.",
             "span": {
               "str": "/// Instantiation with arguments and import-propagation.",
-              "start": 200,
-              "end": 256
+              "start": 232,
+              "end": 288
             }
           }
         ],
@@ -181,8 +194,8 @@
           "string": "d",
           "span": {
             "str": "d",
-            "start": 261,
-            "end": 262
+            "start": 293,
+            "end": 294
           }
         },
         "expr": {
@@ -190,10 +203,11 @@
             "new": {
               "package": {
                 "name": "foo:bar",
+                "version": "3.0.0",
                 "span": {
-                  "str": "foo:bar",
-                  "start": 269,
-                  "end": 276
+                  "str": "foo:bar@3.0.0",
+                  "start": 301,
+                  "end": 314
                 }
               },
               "arguments": [
@@ -202,8 +216,8 @@
                     "string": "a",
                     "span": {
                       "str": "a",
-                      "start": 279,
-                      "end": 280
+                      "start": 317,
+                      "end": 318
                     }
                   }
                 },
@@ -214,8 +228,8 @@
                         "value": "b",
                         "span": {
                           "str": "\"b\"",
-                          "start": 282,
-                          "end": 285
+                          "start": 320,
+                          "end": 323
                         }
                       }
                     },
@@ -226,10 +240,11 @@
                             "new": {
                               "package": {
                                 "name": "foo:bar",
+                                "version": null,
                                 "span": {
                                   "str": "foo:bar",
-                                  "start": 292,
-                                  "end": 299
+                                  "start": 330,
+                                  "end": 337
                                 }
                               },
                               "arguments": [],
@@ -250,8 +265,8 @@
                         "string": "c",
                         "span": {
                           "str": "c",
-                          "start": 306,
-                          "end": 307
+                          "start": 344,
+                          "end": 345
                         }
                       }
                     },
@@ -261,8 +276,8 @@
                           "string": "c",
                           "span": {
                             "str": "c",
-                            "start": 309,
-                            "end": 310
+                            "start": 347,
+                            "end": 348
                           }
                         }
                       },
@@ -285,8 +300,8 @@
             "comment": "Nested expression",
             "span": {
               "str": "/// Nested expression",
-              "start": 320,
-              "end": 341
+              "start": 358,
+              "end": 379
             }
           }
         ],
@@ -294,8 +309,8 @@
           "string": "e",
           "span": {
             "str": "e",
-            "start": 346,
-            "end": 347
+            "start": 384,
+            "end": 385
           }
         },
         "expr": {
@@ -306,8 +321,8 @@
                   "string": "b",
                   "span": {
                     "str": "b",
-                    "start": 351,
-                    "end": 352
+                    "start": 389,
+                    "end": 390
                   }
                 }
               },
@@ -325,8 +340,8 @@
             "comment": "Access expression",
             "span": {
               "str": "/// Access expression",
-              "start": 356,
-              "end": 377
+              "start": 394,
+              "end": 415
             }
           }
         ],
@@ -334,8 +349,8 @@
           "string": "f",
           "span": {
             "str": "f",
-            "start": 382,
-            "end": 383
+            "start": 420,
+            "end": 421
           }
         },
         "expr": {
@@ -344,8 +359,8 @@
               "string": "e",
               "span": {
                 "str": "e",
-                "start": 386,
-                "end": 387
+                "start": 424,
+                "end": 425
               }
             }
           },
@@ -354,15 +369,15 @@
               "namedAccess": {
                 "span": {
                   "str": "[\"b-c\"]",
-                  "start": 387,
-                  "end": 394
+                  "start": 425,
+                  "end": 432
                 },
                 "string": {
                   "value": "b-c",
                   "span": {
                     "str": "\"b-c\"",
-                    "start": 388,
-                    "end": 393
+                    "start": 426,
+                    "end": 431
                   }
                 }
               }
@@ -371,15 +386,15 @@
               "access": {
                 "span": {
                   "str": ".c",
-                  "start": 394,
-                  "end": 396
+                  "start": 432,
+                  "end": 434
                 },
                 "id": {
                   "string": "c",
                   "span": {
                     "str": "c",
-                    "start": 395,
-                    "end": 396
+                    "start": 433,
+                    "end": 434
                   }
                 }
               }
@@ -388,15 +403,15 @@
               "access": {
                 "span": {
                   "str": ".d",
-                  "start": 396,
-                  "end": 398
+                  "start": 434,
+                  "end": 436
                 },
                 "id": {
                   "string": "d",
                   "span": {
                     "str": "d",
-                    "start": 397,
-                    "end": 398
+                    "start": 435,
+                    "end": 436
                   }
                 }
               }
@@ -405,15 +420,15 @@
               "namedAccess": {
                 "span": {
                   "str": "[\"foo:bar/baz\"]",
-                  "start": 398,
-                  "end": 413
+                  "start": 436,
+                  "end": 451
                 },
                 "string": {
                   "value": "foo:bar/baz",
                   "span": {
                     "str": "\"foo:bar/baz\"",
-                    "start": 399,
-                    "end": 412
+                    "start": 437,
+                    "end": 450
                   }
                 }
               }
@@ -422,15 +437,15 @@
               "access": {
                 "span": {
                   "str": ".e",
-                  "start": 413,
-                  "end": 415
+                  "start": 451,
+                  "end": 453
                 },
                 "id": {
                   "string": "e",
                   "span": {
                     "str": "e",
-                    "start": 414,
-                    "end": 415
+                    "start": 452,
+                    "end": 453
                   }
                 }
               }

--- a/crates/wac-parser/tests/parser/resource.wac
+++ b/crates/wac-parser/tests/parser/resource.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface foo {
     /// Resource without methods
     resource r1;

--- a/crates/wac-parser/tests/parser/resource.wac.result
+++ b/crates/wac-parser/tests/parser/resource.wac.result
@@ -1,4 +1,14 @@
 {
+  "docs": [],
+  "package": {
+    "name": "test:comp",
+    "version": null,
+    "span": {
+      "str": "test:comp",
+      "start": 8,
+      "end": 17
+    }
+  },
   "statements": [
     {
       "Type": {
@@ -8,8 +18,8 @@
             "string": "foo",
             "span": {
               "str": "foo",
-              "start": 10,
-              "end": 13
+              "start": 30,
+              "end": 33
             }
           },
           "items": [
@@ -21,8 +31,8 @@
                       "comment": "Resource without methods",
                       "span": {
                         "str": "/// Resource without methods",
-                        "start": 20,
-                        "end": 48
+                        "start": 40,
+                        "end": 68
                       }
                     }
                   ],
@@ -30,8 +40,8 @@
                     "string": "r1",
                     "span": {
                       "str": "r1",
-                      "start": 62,
-                      "end": 64
+                      "start": 82,
+                      "end": 84
                     }
                   },
                   "methods": []
@@ -46,8 +56,8 @@
                       "comment": "Resource with only constructor",
                       "span": {
                         "str": "/// Resource with only constructor",
-                        "start": 71,
-                        "end": 105
+                        "start": 91,
+                        "end": 125
                       }
                     }
                   ],
@@ -55,8 +65,8 @@
                     "string": "r2",
                     "span": {
                       "str": "r2",
-                      "start": 119,
-                      "end": 121
+                      "start": 139,
+                      "end": 141
                     }
                   },
                   "methods": [
@@ -67,15 +77,15 @@
                             "comment": "Constructor",
                             "span": {
                               "str": "/// Constructor",
-                              "start": 132,
-                              "end": 147
+                              "start": 152,
+                              "end": 167
                             }
                           }
                         ],
                         "span": {
                           "str": "constructor",
-                          "start": 156,
-                          "end": 167
+                          "start": 176,
+                          "end": 187
                         },
                         "params": []
                       }
@@ -92,8 +102,8 @@
                       "comment": "Resource with constructor, instance method, and static method",
                       "span": {
                         "str": "/// Resource with constructor, instance method, and static method",
-                        "start": 182,
-                        "end": 247
+                        "start": 202,
+                        "end": 267
                       }
                     }
                   ],
@@ -101,8 +111,8 @@
                     "string": "r3",
                     "span": {
                       "str": "r3",
-                      "start": 261,
-                      "end": 263
+                      "start": 281,
+                      "end": 283
                     }
                   },
                   "methods": [
@@ -113,15 +123,15 @@
                             "comment": "Constructor",
                             "span": {
                               "str": "/// Constructor",
-                              "start": 274,
-                              "end": 289
+                              "start": 294,
+                              "end": 309
                             }
                           }
                         ],
                         "span": {
                           "str": "constructor",
-                          "start": 298,
-                          "end": 309
+                          "start": 318,
+                          "end": 329
                         },
                         "params": [
                           {
@@ -129,8 +139,8 @@
                               "string": "a",
                               "span": {
                                 "str": "a",
-                                "start": 310,
-                                "end": 311
+                                "start": 330,
+                                "end": 331
                               }
                             },
                             "ty": "u32"
@@ -145,8 +155,8 @@
                             "comment": "Method",
                             "span": {
                               "str": "/// Method",
-                              "start": 327,
-                              "end": 337
+                              "start": 347,
+                              "end": 357
                             }
                           }
                         ],
@@ -154,8 +164,8 @@
                           "string": "a",
                           "span": {
                             "str": "a",
-                            "start": 346,
-                            "end": 347
+                            "start": 366,
+                            "end": 367
                           }
                         },
                         "isStatic": false,
@@ -167,8 +177,8 @@
                                   "string": "b",
                                   "span": {
                                     "str": "b",
-                                    "start": 354,
-                                    "end": 355
+                                    "start": 374,
+                                    "end": 375
                                   }
                                 },
                                 "ty": "u32"
@@ -186,8 +196,8 @@
                             "comment": "Static method",
                             "span": {
                               "str": "/// Static method",
-                              "start": 371,
-                              "end": 388
+                              "start": 391,
+                              "end": 408
                             }
                           }
                         ],
@@ -195,8 +205,8 @@
                           "string": "b",
                           "span": {
                             "str": "b",
-                            "start": 397,
-                            "end": 398
+                            "start": 417,
+                            "end": 418
                           }
                         },
                         "isStatic": true,
@@ -208,8 +218,8 @@
                                   "string": "c",
                                   "span": {
                                     "str": "c",
-                                    "start": 412,
-                                    "end": 413
+                                    "start": 432,
+                                    "end": 433
                                   }
                                 },
                                 "ty": "u32"
@@ -236,8 +246,8 @@
             "string": "bar",
             "span": {
               "str": "bar",
-              "start": 436,
-              "end": 439
+              "start": 456,
+              "end": 459
             }
           },
           "items": [
@@ -249,8 +259,8 @@
                       "comment": "Resource without methods",
                       "span": {
                         "str": "/// Resource without methods",
-                        "start": 446,
-                        "end": 474
+                        "start": 466,
+                        "end": 494
                       }
                     }
                   ],
@@ -258,8 +268,8 @@
                     "string": "r1",
                     "span": {
                       "str": "r1",
-                      "start": 488,
-                      "end": 490
+                      "start": 508,
+                      "end": 510
                     }
                   },
                   "methods": []
@@ -274,8 +284,8 @@
                       "comment": "Resource with only constructor",
                       "span": {
                         "str": "/// Resource with only constructor",
-                        "start": 497,
-                        "end": 531
+                        "start": 517,
+                        "end": 551
                       }
                     }
                   ],
@@ -283,8 +293,8 @@
                     "string": "r2",
                     "span": {
                       "str": "r2",
-                      "start": 545,
-                      "end": 547
+                      "start": 565,
+                      "end": 567
                     }
                   },
                   "methods": [
@@ -295,15 +305,15 @@
                             "comment": "Constructor",
                             "span": {
                               "str": "/// Constructor",
-                              "start": 558,
-                              "end": 573
+                              "start": 578,
+                              "end": 593
                             }
                           }
                         ],
                         "span": {
                           "str": "constructor",
-                          "start": 582,
-                          "end": 593
+                          "start": 602,
+                          "end": 613
                         },
                         "params": []
                       }
@@ -320,8 +330,8 @@
                       "comment": "Resource with constructor, instance method, and static method",
                       "span": {
                         "str": "/// Resource with constructor, instance method, and static method",
-                        "start": 608,
-                        "end": 673
+                        "start": 628,
+                        "end": 693
                       }
                     }
                   ],
@@ -329,8 +339,8 @@
                     "string": "r3",
                     "span": {
                       "str": "r3",
-                      "start": 687,
-                      "end": 689
+                      "start": 707,
+                      "end": 709
                     }
                   },
                   "methods": [
@@ -341,15 +351,15 @@
                             "comment": "Constructor",
                             "span": {
                               "str": "/// Constructor",
-                              "start": 700,
-                              "end": 715
+                              "start": 720,
+                              "end": 735
                             }
                           }
                         ],
                         "span": {
                           "str": "constructor",
-                          "start": 724,
-                          "end": 735
+                          "start": 744,
+                          "end": 755
                         },
                         "params": [
                           {
@@ -357,8 +367,8 @@
                               "string": "a",
                               "span": {
                                 "str": "a",
-                                "start": 736,
-                                "end": 737
+                                "start": 756,
+                                "end": 757
                               }
                             },
                             "ty": "u32"
@@ -373,8 +383,8 @@
                             "comment": "Method",
                             "span": {
                               "str": "/// Method",
-                              "start": 753,
-                              "end": 763
+                              "start": 773,
+                              "end": 783
                             }
                           }
                         ],
@@ -382,8 +392,8 @@
                           "string": "a",
                           "span": {
                             "str": "a",
-                            "start": 772,
-                            "end": 773
+                            "start": 792,
+                            "end": 793
                           }
                         },
                         "isStatic": false,
@@ -395,8 +405,8 @@
                                   "string": "b",
                                   "span": {
                                     "str": "b",
-                                    "start": 780,
-                                    "end": 781
+                                    "start": 800,
+                                    "end": 801
                                   }
                                 },
                                 "ty": "u32"
@@ -414,8 +424,8 @@
                             "comment": "Static method",
                             "span": {
                               "str": "/// Static method",
-                              "start": 797,
-                              "end": 814
+                              "start": 817,
+                              "end": 834
                             }
                           }
                         ],
@@ -423,8 +433,8 @@
                           "string": "b",
                           "span": {
                             "str": "b",
-                            "start": 823,
-                            "end": 824
+                            "start": 843,
+                            "end": 844
                           }
                         },
                         "isStatic": true,
@@ -436,8 +446,8 @@
                                   "string": "c",
                                   "span": {
                                     "str": "c",
-                                    "start": 838,
-                                    "end": 839
+                                    "start": 858,
+                                    "end": 859
                                   }
                                 },
                                 "ty": "u32"

--- a/crates/wac-parser/tests/parser/type-alias.wac
+++ b/crates/wac-parser/tests/parser/type-alias.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 /// u8
 type a = u8;
 /// s8

--- a/crates/wac-parser/tests/parser/type-alias.wac.result
+++ b/crates/wac-parser/tests/parser/type-alias.wac.result
@@ -1,4 +1,14 @@
 {
+  "docs": [],
+  "package": {
+    "name": "test:comp",
+    "version": null,
+    "span": {
+      "str": "test:comp",
+      "start": 8,
+      "end": 17
+    }
+  },
   "statements": [
     {
       "Type": {
@@ -9,8 +19,8 @@
                 "comment": "u8",
                 "span": {
                   "str": "/// u8",
-                  "start": 0,
-                  "end": 6
+                  "start": 20,
+                  "end": 26
                 }
               }
             ],
@@ -18,8 +28,8 @@
               "string": "a",
               "span": {
                 "str": "a",
-                "start": 12,
-                "end": 13
+                "start": 32,
+                "end": 33
               }
             },
             "kind": {
@@ -38,8 +48,8 @@
                 "comment": "s8",
                 "span": {
                   "str": "/// s8",
-                  "start": 20,
-                  "end": 26
+                  "start": 40,
+                  "end": 46
                 }
               }
             ],
@@ -47,8 +57,8 @@
               "string": "b",
               "span": {
                 "str": "b",
-                "start": 32,
-                "end": 33
+                "start": 52,
+                "end": 53
               }
             },
             "kind": {
@@ -67,8 +77,8 @@
                 "comment": "u16",
                 "span": {
                   "str": "/// u16",
-                  "start": 40,
-                  "end": 47
+                  "start": 60,
+                  "end": 67
                 }
               }
             ],
@@ -76,8 +86,8 @@
               "string": "c",
               "span": {
                 "str": "c",
-                "start": 53,
-                "end": 54
+                "start": 73,
+                "end": 74
               }
             },
             "kind": {
@@ -96,8 +106,8 @@
                 "comment": "s16",
                 "span": {
                   "str": "/// s16",
-                  "start": 62,
-                  "end": 69
+                  "start": 82,
+                  "end": 89
                 }
               }
             ],
@@ -105,8 +115,8 @@
               "string": "d",
               "span": {
                 "str": "d",
-                "start": 75,
-                "end": 76
+                "start": 95,
+                "end": 96
               }
             },
             "kind": {
@@ -125,8 +135,8 @@
                 "comment": "u32",
                 "span": {
                   "str": "/// u32",
-                  "start": 84,
-                  "end": 91
+                  "start": 104,
+                  "end": 111
                 }
               }
             ],
@@ -134,8 +144,8 @@
               "string": "e",
               "span": {
                 "str": "e",
-                "start": 97,
-                "end": 98
+                "start": 117,
+                "end": 118
               }
             },
             "kind": {
@@ -154,8 +164,8 @@
                 "comment": "s32",
                 "span": {
                   "str": "/// s32",
-                  "start": 106,
-                  "end": 113
+                  "start": 126,
+                  "end": 133
                 }
               }
             ],
@@ -163,8 +173,8 @@
               "string": "f",
               "span": {
                 "str": "f",
-                "start": 119,
-                "end": 120
+                "start": 139,
+                "end": 140
               }
             },
             "kind": {
@@ -183,8 +193,8 @@
                 "comment": "u64",
                 "span": {
                   "str": "/// u64",
-                  "start": 128,
-                  "end": 135
+                  "start": 148,
+                  "end": 155
                 }
               }
             ],
@@ -192,8 +202,8 @@
               "string": "g",
               "span": {
                 "str": "g",
-                "start": 141,
-                "end": 142
+                "start": 161,
+                "end": 162
               }
             },
             "kind": {
@@ -212,8 +222,8 @@
                 "comment": "s64",
                 "span": {
                   "str": "/// s64",
-                  "start": 150,
-                  "end": 157
+                  "start": 170,
+                  "end": 177
                 }
               }
             ],
@@ -221,8 +231,8 @@
               "string": "h",
               "span": {
                 "str": "h",
-                "start": 163,
-                "end": 164
+                "start": 183,
+                "end": 184
               }
             },
             "kind": {
@@ -241,8 +251,8 @@
                 "comment": "float32",
                 "span": {
                   "str": "/// float32",
-                  "start": 172,
-                  "end": 183
+                  "start": 192,
+                  "end": 203
                 }
               }
             ],
@@ -250,8 +260,8 @@
               "string": "i",
               "span": {
                 "str": "i",
-                "start": 189,
-                "end": 190
+                "start": 209,
+                "end": 210
               }
             },
             "kind": {
@@ -270,8 +280,8 @@
                 "comment": "float64",
                 "span": {
                   "str": "/// float64",
-                  "start": 202,
-                  "end": 213
+                  "start": 222,
+                  "end": 233
                 }
               }
             ],
@@ -279,8 +289,8 @@
               "string": "j",
               "span": {
                 "str": "j",
-                "start": 219,
-                "end": 220
+                "start": 239,
+                "end": 240
               }
             },
             "kind": {
@@ -299,8 +309,8 @@
                 "comment": "bool",
                 "span": {
                   "str": "/// bool",
-                  "start": 232,
-                  "end": 240
+                  "start": 252,
+                  "end": 260
                 }
               }
             ],
@@ -308,8 +318,8 @@
               "string": "k",
               "span": {
                 "str": "k",
-                "start": 246,
-                "end": 247
+                "start": 266,
+                "end": 267
               }
             },
             "kind": {
@@ -328,8 +338,8 @@
                 "comment": "char",
                 "span": {
                   "str": "/// char",
-                  "start": 256,
-                  "end": 264
+                  "start": 276,
+                  "end": 284
                 }
               }
             ],
@@ -337,8 +347,8 @@
               "string": "l",
               "span": {
                 "str": "l",
-                "start": 270,
-                "end": 271
+                "start": 290,
+                "end": 291
               }
             },
             "kind": {
@@ -357,8 +367,8 @@
                 "comment": "string",
                 "span": {
                   "str": "/// string",
-                  "start": 280,
-                  "end": 290
+                  "start": 300,
+                  "end": 310
                 }
               }
             ],
@@ -366,8 +376,8 @@
               "string": "m",
               "span": {
                 "str": "m",
-                "start": 296,
-                "end": 297
+                "start": 316,
+                "end": 317
               }
             },
             "kind": {
@@ -386,8 +396,8 @@
                 "comment": "tuple<u8, s8>",
                 "span": {
                   "str": "/// tuple<u8, s8>",
-                  "start": 308,
-                  "end": 325
+                  "start": 328,
+                  "end": 345
                 }
               }
             ],
@@ -395,8 +405,8 @@
               "string": "n",
               "span": {
                 "str": "n",
-                "start": 331,
-                "end": 332
+                "start": 351,
+                "end": 352
               }
             },
             "kind": {
@@ -420,8 +430,8 @@
                 "comment": "list<tuple<u8>>",
                 "span": {
                   "str": "/// list<tuple<u8>>",
-                  "start": 350,
-                  "end": 369
+                  "start": 370,
+                  "end": 389
                 }
               }
             ],
@@ -429,8 +439,8 @@
               "string": "o",
               "span": {
                 "str": "o",
-                "start": 375,
-                "end": 376
+                "start": 395,
+                "end": 396
               }
             },
             "kind": {
@@ -455,8 +465,8 @@
                 "comment": "option<string>",
                 "span": {
                   "str": "/// option<string>",
-                  "start": 396,
-                  "end": 414
+                  "start": 416,
+                  "end": 434
                 }
               }
             ],
@@ -464,8 +474,8 @@
               "string": "p",
               "span": {
                 "str": "p",
-                "start": 420,
-                "end": 421
+                "start": 440,
+                "end": 441
               }
             },
             "kind": {
@@ -486,8 +496,8 @@
                 "comment": "result",
                 "span": {
                   "str": "/// result",
-                  "start": 440,
-                  "end": 450
+                  "start": 460,
+                  "end": 470
                 }
               }
             ],
@@ -495,8 +505,8 @@
               "string": "q",
               "span": {
                 "str": "q",
-                "start": 456,
-                "end": 457
+                "start": 476,
+                "end": 477
               }
             },
             "kind": {
@@ -520,8 +530,8 @@
                 "comment": "result<u8>",
                 "span": {
                   "str": "/// result<u8>",
-                  "start": 468,
-                  "end": 482
+                  "start": 488,
+                  "end": 502
                 }
               }
             ],
@@ -529,8 +539,8 @@
               "string": "r",
               "span": {
                 "str": "r",
-                "start": 488,
-                "end": 489
+                "start": 508,
+                "end": 509
               }
             },
             "kind": {
@@ -554,8 +564,8 @@
                 "comment": "result<_, s8>",
                 "span": {
                   "str": "/// result<_, s8>",
-                  "start": 504,
-                  "end": 521
+                  "start": 524,
+                  "end": 541
                 }
               }
             ],
@@ -563,8 +573,8 @@
               "string": "s",
               "span": {
                 "str": "s",
-                "start": 527,
-                "end": 528
+                "start": 547,
+                "end": 548
               }
             },
             "kind": {
@@ -588,8 +598,8 @@
                 "comment": "result<u8, string>",
                 "span": {
                   "str": "/// result<u8, string>",
-                  "start": 546,
-                  "end": 568
+                  "start": 566,
+                  "end": 588
                 }
               }
             ],
@@ -597,8 +607,8 @@
               "string": "t",
               "span": {
                 "str": "t",
-                "start": 574,
-                "end": 575
+                "start": 594,
+                "end": 595
               }
             },
             "kind": {
@@ -622,8 +632,8 @@
                 "comment": "borrow<x>",
                 "span": {
                   "str": "/// borrow<x>",
-                  "start": 598,
-                  "end": 611
+                  "start": 618,
+                  "end": 631
                 }
               }
             ],
@@ -631,8 +641,8 @@
               "string": "u",
               "span": {
                 "str": "u",
-                "start": 617,
-                "end": 618
+                "start": 637,
+                "end": 638
               }
             },
             "kind": {
@@ -641,8 +651,8 @@
                   "string": "x",
                   "span": {
                     "str": "x",
-                    "start": 628,
-                    "end": 629
+                    "start": 648,
+                    "end": 649
                   }
                 }
               }
@@ -660,8 +670,8 @@
                 "comment": "x",
                 "span": {
                   "str": "/// x",
-                  "start": 632,
-                  "end": 637
+                  "start": 652,
+                  "end": 657
                 }
               }
             ],
@@ -669,8 +679,8 @@
               "string": "v",
               "span": {
                 "str": "v",
-                "start": 643,
-                "end": 644
+                "start": 663,
+                "end": 664
               }
             },
             "kind": {
@@ -679,8 +689,8 @@
                   "string": "x",
                   "span": {
                     "str": "x",
-                    "start": 647,
-                    "end": 648
+                    "start": 667,
+                    "end": 668
                   }
                 }
               }
@@ -698,8 +708,8 @@
                 "comment": "keyword",
                 "span": {
                   "str": "/// keyword",
-                  "start": 650,
-                  "end": 661
+                  "start": 670,
+                  "end": 681
                 }
               }
             ],
@@ -707,8 +717,8 @@
               "string": "type",
               "span": {
                 "str": "%type",
-                "start": 667,
-                "end": 672
+                "start": 687,
+                "end": 692
               }
             },
             "kind": {
@@ -717,8 +727,8 @@
                   "string": "v",
                   "span": {
                     "str": "v",
-                    "start": 675,
-                    "end": 676
+                    "start": 695,
+                    "end": 696
                   }
                 }
               }

--- a/crates/wac-parser/tests/parser/types.wac
+++ b/crates/wac-parser/tests/parser/types.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 /// Defining an interface
 interface i {
     /// Defining a resource

--- a/crates/wac-parser/tests/parser/types.wac.result
+++ b/crates/wac-parser/tests/parser/types.wac.result
@@ -1,4 +1,14 @@
 {
+  "docs": [],
+  "package": {
+    "name": "test:comp",
+    "version": null,
+    "span": {
+      "str": "test:comp",
+      "start": 8,
+      "end": 17
+    }
+  },
   "statements": [
     {
       "Type": {
@@ -8,8 +18,8 @@
               "comment": "Defining an interface",
               "span": {
                 "str": "/// Defining an interface",
-                "start": 0,
-                "end": 25
+                "start": 20,
+                "end": 45
               }
             }
           ],
@@ -17,8 +27,8 @@
             "string": "i",
             "span": {
               "str": "i",
-              "start": 36,
-              "end": 37
+              "start": 56,
+              "end": 57
             }
           },
           "items": [
@@ -30,8 +40,8 @@
                       "comment": "Defining a resource",
                       "span": {
                         "str": "/// Defining a resource",
-                        "start": 44,
-                        "end": 67
+                        "start": 64,
+                        "end": 87
                       }
                     }
                   ],
@@ -39,8 +49,8 @@
                     "string": "res",
                     "span": {
                       "str": "res",
-                      "start": 81,
-                      "end": 84
+                      "start": 101,
+                      "end": 104
                     }
                   },
                   "methods": [
@@ -49,8 +59,8 @@
                         "docs": [],
                         "span": {
                           "str": "constructor",
-                          "start": 95,
-                          "end": 106
+                          "start": 115,
+                          "end": 126
                         },
                         "params": []
                       }
@@ -67,8 +77,8 @@
                       "comment": "Type alias a",
                       "span": {
                         "str": "/// Type alias a",
-                        "start": 121,
-                        "end": 137
+                        "start": 141,
+                        "end": 157
                       }
                     }
                   ],
@@ -76,8 +86,8 @@
                     "string": "a",
                     "span": {
                       "str": "a",
-                      "start": 147,
-                      "end": 148
+                      "start": 167,
+                      "end": 168
                     }
                   },
                   "kind": {
@@ -97,8 +107,8 @@
                       "comment": "Record type",
                       "span": {
                         "str": "/// Record type",
-                        "start": 163,
-                        "end": 178
+                        "start": 183,
+                        "end": 198
                       }
                     }
                   ],
@@ -106,8 +116,8 @@
                     "string": "r",
                     "span": {
                       "str": "r",
-                      "start": 190,
-                      "end": 191
+                      "start": 210,
+                      "end": 211
                     }
                   },
                   "fields": [
@@ -117,8 +127,8 @@
                         "string": "x",
                         "span": {
                           "str": "x",
-                          "start": 202,
-                          "end": 203
+                          "start": 222,
+                          "end": 223
                         }
                       },
                       "ty": "u32"
@@ -134,8 +144,8 @@
                     "comment": "Export func",
                     "span": {
                       "str": "/// Export func",
-                      "start": 219,
-                      "end": 234
+                      "start": 239,
+                      "end": 254
                     }
                   }
                 ],
@@ -143,8 +153,8 @@
                   "string": "x",
                   "span": {
                     "str": "x",
-                    "start": 239,
-                    "end": 240
+                    "start": 259,
+                    "end": 260
                   }
                 },
                 "ty": {
@@ -162,8 +172,8 @@
                     "comment": "Export func of type a",
                     "span": {
                       "str": "/// Export func of type a",
-                      "start": 254,
-                      "end": 279
+                      "start": 274,
+                      "end": 299
                     }
                   }
                 ],
@@ -171,8 +181,8 @@
                   "string": "y",
                   "span": {
                     "str": "y",
-                    "start": 284,
-                    "end": 285
+                    "start": 304,
+                    "end": 305
                   }
                 },
                 "ty": {
@@ -180,8 +190,8 @@
                     "string": "a",
                     "span": {
                       "str": "a",
-                      "start": 287,
-                      "end": 288
+                      "start": 307,
+                      "end": 308
                     }
                   }
                 }
@@ -199,8 +209,8 @@
               "comment": "Defining a second interface",
               "span": {
                 "str": "/// Defining a second interface",
-                "start": 293,
-                "end": 324
+                "start": 313,
+                "end": 344
               }
             }
           ],
@@ -208,8 +218,8 @@
             "string": "i2",
             "span": {
               "str": "i2",
-              "start": 335,
-              "end": 337
+              "start": 355,
+              "end": 357
             }
           },
           "items": [
@@ -220,8 +230,8 @@
                     "comment": "Use type r from i",
                     "span": {
                       "str": "/// Use type r from i",
-                      "start": 344,
-                      "end": 365
+                      "start": 364,
+                      "end": 385
                     }
                   }
                 ],
@@ -230,8 +240,8 @@
                     "string": "i",
                     "span": {
                       "str": "i",
-                      "start": 374,
-                      "end": 375
+                      "start": 394,
+                      "end": 395
                     }
                   }
                 },
@@ -241,8 +251,8 @@
                       "string": "r",
                       "span": {
                         "str": "r",
-                        "start": 377,
-                        "end": 378
+                        "start": 397,
+                        "end": 398
                       }
                     },
                     "asId": null
@@ -257,8 +267,8 @@
                     "comment": "Use type r from i with alias z",
                     "span": {
                       "str": "/// Use type r from i with alias z",
-                      "start": 386,
-                      "end": 420
+                      "start": 406,
+                      "end": 440
                     }
                   }
                 ],
@@ -267,8 +277,8 @@
                     "string": "i",
                     "span": {
                       "str": "i",
-                      "start": 429,
-                      "end": 430
+                      "start": 449,
+                      "end": 450
                     }
                   }
                 },
@@ -278,16 +288,16 @@
                       "string": "r",
                       "span": {
                         "str": "r",
-                        "start": 432,
-                        "end": 433
+                        "start": 452,
+                        "end": 453
                       }
                     },
                     "asId": {
                       "string": "z",
                       "span": {
                         "str": "z",
-                        "start": 437,
-                        "end": 438
+                        "start": 457,
+                        "end": 458
                       }
                     }
                   }
@@ -306,8 +316,8 @@
               "comment": "Defining a world",
               "span": {
                 "str": "/// Defining a world",
-                "start": 444,
-                "end": 464
+                "start": 464,
+                "end": 484
               }
             }
           ],
@@ -315,8 +325,8 @@
             "string": "w1",
             "span": {
               "str": "w1",
-              "start": 471,
-              "end": 473
+              "start": 491,
+              "end": 493
             }
           },
           "items": [
@@ -327,8 +337,8 @@
                     "comment": "Use type r from foo:bar/i",
                     "span": {
                       "str": "/// Use type r from foo:bar/i",
-                      "start": 480,
-                      "end": 509
+                      "start": 500,
+                      "end": 529
                     }
                   }
                 ],
@@ -336,8 +346,8 @@
                   "package": {
                     "span": {
                       "str": "foo:bar/i",
-                      "start": 518,
-                      "end": 527
+                      "start": 538,
+                      "end": 547
                     },
                     "name": "foo:bar",
                     "segments": "i",
@@ -350,8 +360,8 @@
                       "string": "r",
                       "span": {
                         "str": "r",
-                        "start": 529,
-                        "end": 530
+                        "start": 549,
+                        "end": 550
                       }
                     },
                     "asId": null
@@ -366,8 +376,8 @@
                     "comment": "Import a function",
                     "span": {
                       "str": "/// Import a function",
-                      "start": 538,
-                      "end": 559
+                      "start": 558,
+                      "end": 579
                     }
                   }
                 ],
@@ -377,8 +387,8 @@
                       "string": "a",
                       "span": {
                         "str": "a",
-                        "start": 571,
-                        "end": 572
+                        "start": 591,
+                        "end": 592
                       }
                     },
                     "ty": {
@@ -398,8 +408,8 @@
                     "comment": "Import an interface",
                     "span": {
                       "str": "/// Import an interface",
-                      "start": 586,
-                      "end": 609
+                      "start": 606,
+                      "end": 629
                     }
                   }
                 ],
@@ -408,8 +418,8 @@
                     "string": "i",
                     "span": {
                       "str": "i",
-                      "start": 621,
-                      "end": 622
+                      "start": 641,
+                      "end": 642
                     }
                   }
                 }
@@ -422,8 +432,8 @@
                     "comment": "Import by name with type `c`",
                     "span": {
                       "str": "/// Import by name with type `c`",
-                      "start": 628,
-                      "end": 660
+                      "start": 648,
+                      "end": 680
                     }
                   }
                 ],
@@ -433,8 +443,8 @@
                       "string": "c",
                       "span": {
                         "str": "c",
-                        "start": 672,
-                        "end": 673
+                        "start": 692,
+                        "end": 693
                       }
                     },
                     "ty": {
@@ -442,8 +452,8 @@
                         "string": "c",
                         "span": {
                           "str": "c",
-                          "start": 675,
-                          "end": 676
+                          "start": 695,
+                          "end": 696
                         }
                       }
                     }
@@ -458,8 +468,8 @@
                     "comment": "Export an inline interface",
                     "span": {
                       "str": "/// Export an inline interface",
-                      "start": 683,
-                      "end": 713
+                      "start": 703,
+                      "end": 733
                     }
                   }
                 ],
@@ -469,8 +479,8 @@
                       "string": "d",
                       "span": {
                         "str": "d",
-                        "start": 725,
-                        "end": 726
+                        "start": 745,
+                        "end": 746
                       }
                     },
                     "ty": {
@@ -483,8 +493,8 @@
                                 "string": "x",
                                 "span": {
                                   "str": "x",
-                                  "start": 748,
-                                  "end": 749
+                                  "start": 768,
+                                  "end": 769
                                 }
                               },
                               "ty": {
@@ -509,8 +519,8 @@
                     "comment": "Export an interface",
                     "span": {
                       "str": "/// Export an interface",
-                      "start": 770,
-                      "end": 793
+                      "start": 790,
+                      "end": 813
                     }
                   }
                 ],
@@ -519,8 +529,8 @@
                     "string": "i2",
                     "span": {
                       "str": "i2",
-                      "start": 805,
-                      "end": 807
+                      "start": 825,
+                      "end": 827
                     }
                   }
                 }
@@ -533,8 +543,8 @@
                     "comment": "Export by name with type `f`",
                     "span": {
                       "str": "/// Export by name with type `f`",
-                      "start": 813,
-                      "end": 845
+                      "start": 833,
+                      "end": 865
                     }
                   }
                 ],
@@ -544,8 +554,8 @@
                       "string": "f",
                       "span": {
                         "str": "f",
-                        "start": 857,
-                        "end": 858
+                        "start": 877,
+                        "end": 878
                       }
                     },
                     "ty": {
@@ -553,8 +563,8 @@
                         "string": "f",
                         "span": {
                           "str": "f",
-                          "start": 860,
-                          "end": 861
+                          "start": 880,
+                          "end": 881
                         }
                       }
                     }
@@ -574,8 +584,8 @@
               "comment": "Defining a second world",
               "span": {
                 "str": "/// Defining a second world",
-                "start": 866,
-                "end": 893
+                "start": 886,
+                "end": 913
               }
             }
           ],
@@ -583,8 +593,8 @@
             "string": "w2",
             "span": {
               "str": "w2",
-              "start": 900,
-              "end": 902
+              "start": 920,
+              "end": 922
             }
           },
           "items": [
@@ -595,8 +605,8 @@
                     "comment": "Include the first world",
                     "span": {
                       "str": "/// Include the first world",
-                      "start": 909,
-                      "end": 936
+                      "start": 929,
+                      "end": 956
                     }
                   }
                 ],
@@ -605,8 +615,8 @@
                     "string": "w1",
                     "span": {
                       "str": "w1",
-                      "start": 949,
-                      "end": 951
+                      "start": 969,
+                      "end": 971
                     }
                   }
                 },
@@ -620,8 +630,8 @@
                     "comment": "Include a world by path",
                     "span": {
                       "str": "/// Include a world by path",
-                      "start": 958,
-                      "end": 985
+                      "start": 978,
+                      "end": 1005
                     }
                   }
                 ],
@@ -629,8 +639,8 @@
                   "package": {
                     "span": {
                       "str": "foo:bar/baz",
-                      "start": 998,
-                      "end": 1009
+                      "start": 1018,
+                      "end": 1029
                     },
                     "name": "foo:bar",
                     "segments": "baz",
@@ -653,8 +663,8 @@
                 "comment": "Defining a variant",
                 "span": {
                   "str": "/// Defining a variant",
-                  "start": 1014,
-                  "end": 1036
+                  "start": 1034,
+                  "end": 1056
                 }
               }
             ],
@@ -662,8 +672,8 @@
               "string": "v",
               "span": {
                 "str": "v",
-                "start": 1045,
-                "end": 1046
+                "start": 1065,
+                "end": 1066
               }
             },
             "cases": [
@@ -673,8 +683,8 @@
                   "string": "a",
                   "span": {
                     "str": "a",
-                    "start": 1053,
-                    "end": 1054
+                    "start": 1073,
+                    "end": 1074
                   }
                 },
                 "ty": {
@@ -682,8 +692,8 @@
                     "string": "x",
                     "span": {
                       "str": "x",
-                      "start": 1055,
-                      "end": 1056
+                      "start": 1075,
+                      "end": 1076
                     }
                   }
                 }
@@ -694,8 +704,8 @@
                   "string": "b",
                   "span": {
                     "str": "b",
-                    "start": 1063,
-                    "end": 1064
+                    "start": 1083,
+                    "end": 1084
                   }
                 },
                 "ty": "string"
@@ -706,8 +716,8 @@
                   "string": "c",
                   "span": {
                     "str": "c",
-                    "start": 1078,
-                    "end": 1079
+                    "start": 1098,
+                    "end": 1099
                   }
                 },
                 "ty": "u32"
@@ -718,8 +728,8 @@
                   "string": "d",
                   "span": {
                     "str": "d",
-                    "start": 1090,
-                    "end": 1091
+                    "start": 1110,
+                    "end": 1111
                   }
                 },
                 "ty": null
@@ -738,8 +748,8 @@
                 "comment": "Defining a record",
                 "span": {
                   "str": "/// Defining a record",
-                  "start": 1096,
-                  "end": 1117
+                  "start": 1116,
+                  "end": 1137
                 }
               }
             ],
@@ -747,8 +757,8 @@
               "string": "r",
               "span": {
                 "str": "r",
-                "start": 1125,
-                "end": 1126
+                "start": 1145,
+                "end": 1146
               }
             },
             "fields": [
@@ -758,8 +768,8 @@
                   "string": "x",
                   "span": {
                     "str": "x",
-                    "start": 1133,
-                    "end": 1134
+                    "start": 1153,
+                    "end": 1154
                   }
                 },
                 "ty": "u32"
@@ -770,8 +780,8 @@
                   "string": "y",
                   "span": {
                     "str": "y",
-                    "start": 1145,
-                    "end": 1146
+                    "start": 1165,
+                    "end": 1166
                   }
                 },
                 "ty": "string"
@@ -782,8 +792,8 @@
                   "string": "z",
                   "span": {
                     "str": "z",
-                    "start": 1160,
-                    "end": 1161
+                    "start": 1180,
+                    "end": 1181
                   }
                 },
                 "ty": {
@@ -791,8 +801,8 @@
                     "string": "v",
                     "span": {
                       "str": "v",
-                      "start": 1163,
-                      "end": 1164
+                      "start": 1183,
+                      "end": 1184
                     }
                   }
                 }
@@ -811,8 +821,8 @@
                 "comment": "Defining flags",
                 "span": {
                   "str": "/// Defining flags",
-                  "start": 1170,
-                  "end": 1188
+                  "start": 1190,
+                  "end": 1208
                 }
               }
             ],
@@ -820,8 +830,8 @@
               "string": "f",
               "span": {
                 "str": "f",
-                "start": 1195,
-                "end": 1196
+                "start": 1215,
+                "end": 1216
               }
             },
             "flags": [
@@ -831,8 +841,8 @@
                   "string": "a",
                   "span": {
                     "str": "a",
-                    "start": 1203,
-                    "end": 1204
+                    "start": 1223,
+                    "end": 1224
                   }
                 }
               },
@@ -842,8 +852,8 @@
                   "string": "b",
                   "span": {
                     "str": "b",
-                    "start": 1210,
-                    "end": 1211
+                    "start": 1230,
+                    "end": 1231
                   }
                 }
               },
@@ -853,8 +863,8 @@
                   "string": "c",
                   "span": {
                     "str": "c",
-                    "start": 1217,
-                    "end": 1218
+                    "start": 1237,
+                    "end": 1238
                   }
                 }
               }
@@ -872,8 +882,8 @@
                 "comment": "Defining an enum",
                 "span": {
                   "str": "/// Defining an enum",
-                  "start": 1223,
-                  "end": 1243
+                  "start": 1243,
+                  "end": 1263
                 }
               }
             ],
@@ -881,8 +891,8 @@
               "string": "e",
               "span": {
                 "str": "e",
-                "start": 1249,
-                "end": 1250
+                "start": 1269,
+                "end": 1270
               }
             },
             "cases": [
@@ -892,8 +902,8 @@
                   "string": "a",
                   "span": {
                     "str": "a",
-                    "start": 1257,
-                    "end": 1258
+                    "start": 1277,
+                    "end": 1278
                   }
                 }
               },
@@ -903,8 +913,8 @@
                   "string": "b",
                   "span": {
                     "str": "b",
-                    "start": 1264,
-                    "end": 1265
+                    "start": 1284,
+                    "end": 1285
                   }
                 }
               },
@@ -914,8 +924,8 @@
                   "string": "c",
                   "span": {
                     "str": "c",
-                    "start": 1271,
-                    "end": 1272
+                    "start": 1291,
+                    "end": 1292
                   }
                 }
               }
@@ -933,8 +943,8 @@
                 "comment": "Type aliases",
                 "span": {
                   "str": "/// Type aliases",
-                  "start": 1277,
-                  "end": 1293
+                  "start": 1297,
+                  "end": 1313
                 }
               }
             ],
@@ -942,8 +952,8 @@
               "string": "t",
               "span": {
                 "str": "t",
-                "start": 1299,
-                "end": 1300
+                "start": 1319,
+                "end": 1320
               }
             },
             "kind": {
@@ -952,8 +962,8 @@
                   "string": "e",
                   "span": {
                     "str": "e",
-                    "start": 1303,
-                    "end": 1304
+                    "start": 1323,
+                    "end": 1324
                   }
                 }
               }
@@ -971,8 +981,8 @@
               "string": "t2",
               "span": {
                 "str": "t2",
-                "start": 1311,
-                "end": 1313
+                "start": 1331,
+                "end": 1333
               }
             },
             "kind": {
@@ -991,8 +1001,8 @@
               "string": "t3",
               "span": {
                 "str": "t3",
-                "start": 1329,
-                "end": 1331
+                "start": 1349,
+                "end": 1351
               }
             },
             "kind": {
@@ -1003,8 +1013,8 @@
                       "string": "a",
                       "span": {
                         "str": "a",
-                        "start": 1339,
-                        "end": 1340
+                        "start": 1359,
+                        "end": 1360
                       }
                     },
                     "ty": "u32"
@@ -1014,8 +1024,8 @@
                       "string": "b",
                       "span": {
                         "str": "b",
-                        "start": 1347,
-                        "end": 1348
+                        "start": 1367,
+                        "end": 1368
                       }
                     },
                     "ty": {
@@ -1023,8 +1033,8 @@
                         "string": "r",
                         "span": {
                           "str": "r",
-                          "start": 1350,
-                          "end": 1351
+                          "start": 1370,
+                          "end": 1371
                         }
                       }
                     }
@@ -1048,8 +1058,8 @@
               "string": "t4",
               "span": {
                 "str": "t4",
-                "start": 1366,
-                "end": 1368
+                "start": 1386,
+                "end": 1388
               }
             },
             "kind": {
@@ -1062,8 +1072,8 @@
                         "string": "a",
                         "span": {
                           "str": "a",
-                          "start": 1382,
-                          "end": 1383
+                          "start": 1402,
+                          "end": 1403
                         }
                       },
                       "ty": "u32"
@@ -1073,8 +1083,8 @@
                         "string": "b",
                         "span": {
                           "str": "b",
-                          "start": 1390,
-                          "end": 1391
+                          "start": 1410,
+                          "end": 1411
                         }
                       },
                       "ty": "string"

--- a/crates/wac-parser/tests/resolution.rs
+++ b/crates/wac-parser/tests/resolution.rs
@@ -88,7 +88,6 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<()> {
         .map_err(|e| anyhow!("{e}", e = ErrorFormatter::new(test, e, false)))?;
     let result = match ResolvedDocument::new(
         &document,
-        "test:test",
         Some(Box::new(FileSystemPackageResolver::new(
             test.parent().unwrap().join(test.file_stem().unwrap()),
             Default::default(),

--- a/crates/wac-parser/tests/resolution/alias.wac
+++ b/crates/wac-parser/tests/resolution/alias.wac
@@ -1,3 +1,5 @@
+package test:comp@1.0.0;
+
 type a = u32;
 
 type b = string;

--- a/crates/wac-parser/tests/resolution/alias.wac.result
+++ b/crates/wac-parser/tests/resolution/alias.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "1.0.0",
   "definitions": {
     "types": [
       {

--- a/crates/wac-parser/tests/resolution/duplicate-world-item.wac
+++ b/crates/wac-parser/tests/resolution/duplicate-world-item.wac
@@ -1,3 +1,5 @@
+package test:comp@2.0.0;
+
 world w {
     import x: func();
     export x: func();

--- a/crates/wac-parser/tests/resolution/duplicate-world-item.wac.result
+++ b/crates/wac-parser/tests/resolution/duplicate-world-item.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "2.0.0",
   "definitions": {
     "types": [],
     "resources": [],

--- a/crates/wac-parser/tests/resolution/fail/duplicate-enum-case.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-enum-case.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 enum e {
     a,
     b,

--- a/crates/wac-parser/tests/resolution/fail/duplicate-enum-case.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-enum-case.wac.result
@@ -1,5 +1,5 @@
 duplicate case `b` for enum type `e`
-    --> tests/resolution/fail/duplicate-enum-case.wac:5:5
+    --> tests/resolution/fail/duplicate-enum-case.wac:7:5
      |
-   5 |     b,
+   7 |     b,
      |     ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-flag.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-flag.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 flags f {
     a,
     b,

--- a/crates/wac-parser/tests/resolution/fail/duplicate-flag.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-flag.wac.result
@@ -1,5 +1,5 @@
 duplicate flag `a` for flags type `f`
-    --> tests/resolution/fail/duplicate-flag.wac:6:5
+    --> tests/resolution/fail/duplicate-flag.wac:8:5
      |
-   6 |     a,
+   8 |     a,
      |     ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-func-param.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-func-param.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 type f = func(x: u32, x: string);

--- a/crates/wac-parser/tests/resolution/fail/duplicate-func-param.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-func-param.wac.result
@@ -1,5 +1,5 @@
 duplicate function parameter `x`
-    --> tests/resolution/fail/duplicate-func-param.wac:1:23
+    --> tests/resolution/fail/duplicate-func-param.wac:3:23
      |
-   1 | type f = func(x: u32, x: string);
+   3 | type f = func(x: u32, x: string);
      |                       ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-func-result.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-func-result.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 type f = func() -> (a: u32, a: s8);

--- a/crates/wac-parser/tests/resolution/fail/duplicate-func-result.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-func-result.wac.result
@@ -1,5 +1,5 @@
 duplicate function result `a`
-    --> tests/resolution/fail/duplicate-func-result.wac:1:29
+    --> tests/resolution/fail/duplicate-func-result.wac:3:29
      |
-   1 | type f = func() -> (a: u32, a: s8);
+   3 | type f = func() -> (a: u32, a: s8);
      |                             ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-interface-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-interface-export.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface x {
     x: func();
     x: func();

--- a/crates/wac-parser/tests/resolution/fail/duplicate-interface-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-interface-export.wac.result
@@ -1,5 +1,5 @@
 duplicate interface export `x` for interface `x`
-    --> tests/resolution/fail/duplicate-interface-export.wac:3:5
+    --> tests/resolution/fail/duplicate-interface-export.wac:5:5
      |
-   3 |     x: func();
+   5 |     x: func();
      |     ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-name-in-include.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-name-in-include.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w1 {
 
 }

--- a/crates/wac-parser/tests/resolution/fail/duplicate-name-in-include.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-name-in-include.wac.result
@@ -1,5 +1,5 @@
 duplicate `a` in world include `with` clause
-    --> tests/resolution/fail/duplicate-name-in-include.wac:6:31
+    --> tests/resolution/fail/duplicate-name-in-include.wac:8:31
      |
-   6 |     include w1 with { a as b, a as c};
+   8 |     include w1 with { a as b, a as c};
      |                               ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-record-field.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-record-field.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = string;
 
 record r {

--- a/crates/wac-parser/tests/resolution/fail/duplicate-record-field.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-record-field.wac.result
@@ -1,5 +1,5 @@
 duplicate field `b` for record type `r`
-    --> tests/resolution/fail/duplicate-record-field.wac:7:5
+    --> tests/resolution/fail/duplicate-record-field.wac:9:5
      |
-   7 |     b: string,
+   9 |     b: string,
      |     ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor-param.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor-param.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface foo {
     resource x {
         constructor(a: u32, a: string);

--- a/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor-param.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor-param.wac.result
@@ -1,5 +1,5 @@
 duplicate constructor parameter `a`
-    --> tests/resolution/fail/duplicate-resource-constructor-param.wac:3:29
+    --> tests/resolution/fail/duplicate-resource-constructor-param.wac:5:29
      |
-   3 |         constructor(a: u32, a: string);
+   5 |         constructor(a: u32, a: string);
      |                             ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface foo {
     resource x {
         constructor();

--- a/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-resource-constructor.wac.result
@@ -1,5 +1,5 @@
 duplicate constructor for resource `x`
-    --> tests/resolution/fail/duplicate-resource-constructor.wac:4:9
+    --> tests/resolution/fail/duplicate-resource-constructor.wac:6:9
      |
-   4 |         constructor(x: u32);
+   6 |         constructor(x: u32);
      |         ^---------^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-resource-method.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-resource-method.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world foo {
     resource x {
         x: func();

--- a/crates/wac-parser/tests/resolution/fail/duplicate-resource-method.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-resource-method.wac.result
@@ -1,5 +1,5 @@
 duplicate method `x` for resource `x`
-    --> tests/resolution/fail/duplicate-resource-method.wac:4:9
+    --> tests/resolution/fail/duplicate-resource-method.wac:6:9
      |
-   4 |         x: static func();
+   6 |         x: static func();
      |         ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-variant-case.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-variant-case.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = string;
 
 variant x {

--- a/crates/wac-parser/tests/resolution/fail/duplicate-variant-case.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-variant-case.wac.result
@@ -1,5 +1,5 @@
 duplicate case `a` for variant type `x`
-    --> tests/resolution/fail/duplicate-variant-case.wac:6:5
+    --> tests/resolution/fail/duplicate-variant-case.wac:8:5
      |
-   6 |     a,
+   8 |     a,
      |     ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-world-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-world-export.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w {
     export x: func();
     export x: func();

--- a/crates/wac-parser/tests/resolution/fail/duplicate-world-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-world-export.wac.result
@@ -1,5 +1,5 @@
 export `x` conflicts with existing export of the same name in world `w`
-    --> tests/resolution/fail/duplicate-world-export.wac:3:12
+    --> tests/resolution/fail/duplicate-world-export.wac:5:12
      |
-   3 |     export x: func();
+   5 |     export x: func();
      |            ^

--- a/crates/wac-parser/tests/resolution/fail/duplicate-world-import.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-world-import.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w {
     import x: func();
     import x: func();

--- a/crates/wac-parser/tests/resolution/fail/duplicate-world-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-world-import.wac.result
@@ -1,5 +1,5 @@
 import `x` conflicts with existing import of the same name in world `w`
-    --> tests/resolution/fail/duplicate-world-import.wac:3:12
+    --> tests/resolution/fail/duplicate-world-import.wac:5:12
      |
-   3 |     import x: func();
+   5 |     import x: func();
      |            ^

--- a/crates/wac-parser/tests/resolution/fail/expected-result-named.wac
+++ b/crates/wac-parser/tests/resolution/fail/expected-result-named.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> string;
 };

--- a/crates/wac-parser/tests/resolution/fail/expected-result-named.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/expected-result-named.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/expected-result-named.wac:5:23
+    --> tests/resolution/fail/expected-result-named.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/expected-result-scalar.wac
+++ b/crates/wac-parser/tests/resolution/fail/expected-result-scalar.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> (x: u32, y: string);
 };

--- a/crates/wac-parser/tests/resolution/fail/expected-result-scalar.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/expected-result-scalar.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/expected-result-scalar.wac:5:23
+    --> tests/resolution/fail/expected-result-scalar.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import f with "x": func();
 
 type x = u32;

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac.result
@@ -1,5 +1,5 @@
-export `x` conflicts with u32 definition at tests/resolution/fail/export-conflict-alias.wac:3:6 (consider using a `with` clause to use a different name)
-    --> tests/resolution/fail/export-conflict-alias.wac:5:1
+export `x` conflicts with u32 definition at tests/resolution/fail/export-conflict-alias.wac:5:6 (consider using a `with` clause to use a different name)
+    --> tests/resolution/fail/export-conflict-alias.wac:7:1
      |
-   5 | export f;
+   7 | export f;
      | ^----^

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import f: func();
 
 interface foo {

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac.result
@@ -1,5 +1,5 @@
-export `foo` conflicts with interface definition at tests/resolution/fail/export-conflict-interface.wac:3:11
-    --> tests/resolution/fail/export-conflict-interface.wac:7:15
+export `foo` conflicts with interface definition at tests/resolution/fail/export-conflict-interface.wac:5:11
+    --> tests/resolution/fail/export-conflict-interface.wac:9:15
      |
-   7 | export f with "foo";
+   9 | export f with "foo";
      |               ^---^

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import f with "x": func();
 
 record x {

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac.result
@@ -1,5 +1,5 @@
-export `x` conflicts with record definition at tests/resolution/fail/export-conflict-type.wac:3:8
-    --> tests/resolution/fail/export-conflict-type.wac:7:15
+export `x` conflicts with record definition at tests/resolution/fail/export-conflict-type.wac:5:8
+    --> tests/resolution/fail/export-conflict-type.wac:9:15
      |
-   7 | export f with "x";
+   9 | export f with "x";
      |               ^-^

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import f: func();
 
 world foo {

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac.result
@@ -1,5 +1,5 @@
-export `foo` conflicts with world definition at tests/resolution/fail/export-conflict-world.wac:3:7
-    --> tests/resolution/fail/export-conflict-world.wac:7:15
+export `foo` conflicts with world definition at tests/resolution/fail/export-conflict-world.wac:5:7
+    --> tests/resolution/fail/export-conflict-world.wac:9:15
      |
-   7 | export f with "foo";
+   9 | export f with "foo";
      |               ^---^

--- a/crates/wac-parser/tests/resolution/fail/export-dep-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-dep-name.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 import f: func();
 export f with "locked-dep=<foo:bar>";

--- a/crates/wac-parser/tests/resolution/fail/export-dep-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-dep-name.wac.result
@@ -1,7 +1,7 @@
 export name `locked-dep=<foo:bar>` is not valid
-    --> tests/resolution/fail/export-dep-name.wac:2:15
+    --> tests/resolution/fail/export-dep-name.wac:4:15
      |
-   2 | export f with "locked-dep=<foo:bar>";
+   4 | export f with "locked-dep=<foo:bar>";
      |               ^--------------------^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import f: func();
 export f with "x";
 export f with "x";

--- a/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac.result
@@ -1,5 +1,5 @@
 duplicate export `x`
-    --> tests/resolution/fail/export-duplicate-name.wac:3:15
+    --> tests/resolution/fail/export-duplicate-name.wac:5:15
      |
-   3 | export f with "x";
+   5 | export f with "x";
      |               ^-^

--- a/crates/wac-parser/tests/resolution/fail/export-hash-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-hash-name.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 import f: func();
 export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";

--- a/crates/wac-parser/tests/resolution/fail/export-hash-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-hash-name.wac.result
@@ -1,7 +1,7 @@
 export name `integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>` is not valid
-    --> tests/resolution/fail/export-hash-name.wac:2:15
+    --> tests/resolution/fail/export-hash-name.wac:4:15
      |
-   2 | export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";
+   4 | export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";
      |               ^-----------------------------------------------------------------------------------^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 import f: func();
 export f with "INVALID!";

--- a/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac.result
@@ -1,7 +1,7 @@
 export name `INVALID!` is not valid
-    --> tests/resolution/fail/export-invalid-name.wac:2:15
+    --> tests/resolution/fail/export-invalid-name.wac:4:15
      |
-   2 | export f with "INVALID!";
+   4 | export f with "INVALID!";
      |               ^--------^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/export-needs-with.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-needs-with.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 let i = new foo:bar {};
 export i;

--- a/crates/wac-parser/tests/resolution/fail/export-needs-with.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-needs-with.wac.result
@@ -1,5 +1,5 @@
 export statement requires a `with` clause as the export name cannot be inferred
-    --> tests/resolution/fail/export-needs-with.wac:2:1
+    --> tests/resolution/fail/export-needs-with.wac:4:1
      |
-   2 | export i;
+   4 | export i;
      | ^----^

--- a/crates/wac-parser/tests/resolution/fail/export-url-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-url-name.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 import f: func();
 export f with "url=<https://example.com/foo>";

--- a/crates/wac-parser/tests/resolution/fail/export-url-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-url-name.wac.result
@@ -1,7 +1,7 @@
 export name `url=<https://example.com/foo>` is not valid
-    --> tests/resolution/fail/export-url-name.wac:2:15
+    --> tests/resolution/fail/export-url-name.wac:4:15
      |
-   2 | export f with "url=<https://example.com/foo>";
+   4 | export f with "url=<https://example.com/foo>";
      |               ^-----------------------------^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/func-results-not-present.wac
+++ b/crates/wac-parser/tests/resolution/fail/func-results-not-present.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func();
 };

--- a/crates/wac-parser/tests/resolution/fail/func-results-not-present.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/func-results-not-present.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/func-results-not-present.wac:5:23
+    --> tests/resolution/fail/func-results-not-present.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/func-results-present.wac
+++ b/crates/wac-parser/tests/resolution/fail/func-results-present.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> string;
 };

--- a/crates/wac-parser/tests/resolution/fail/func-results-present.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/func-results-present.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/func-results-present.wac:5:23
+    --> tests/resolution/fail/func-results-present.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 import x with "foo": func();
 import y with "foo": interface {};

--- a/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac.result
@@ -1,5 +1,5 @@
 duplicate import `foo`
-    --> tests/resolution/fail/import-duplicate-name.wac:2:15
+    --> tests/resolution/fail/import-duplicate-name.wac:4:15
      |
-   2 | import y with "foo": interface {};
+   4 | import y with "foo": interface {};
      |               ^---^

--- a/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 import x with "NOT-VALID-NAME!": func();

--- a/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac.result
@@ -1,7 +1,7 @@
 import name `NOT-VALID-NAME!` is not valid
-    --> tests/resolution/fail/import-invalid-name.wac:1:15
+    --> tests/resolution/fail/import-invalid-name.wac:3:15
      |
-   1 | import x with "NOT-VALID-NAME!": func();
+   3 | import x with "NOT-VALID-NAME!": func();
      |               ^---------------^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/invalid-alias.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-alias.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface a {
 
 }

--- a/crates/wac-parser/tests/resolution/fail/invalid-alias.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-alias.wac.result
@@ -1,5 +1,5 @@
 `a` (interface) cannot be used in a type alias
-    --> tests/resolution/fail/invalid-alias.wac:5:10
+    --> tests/resolution/fail/invalid-alias.wac:7:10
      |
-   5 | type x = a;
+   7 | type x = a;
      |          ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-borrow.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-borrow.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 type y = borrow<x>;

--- a/crates/wac-parser/tests/resolution/fail/invalid-borrow.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-borrow.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not a resource type
-    --> tests/resolution/fail/invalid-borrow.wac:3:17
+    --> tests/resolution/fail/invalid-borrow.wac:5:17
      |
-   3 | type y = borrow<x>;
+   5 | type y = borrow<x>;
      |                 ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-func-type-ref.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-func-type-ref.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 interface i {

--- a/crates/wac-parser/tests/resolution/fail/invalid-func-type-ref.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-func-type-ref.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not a function type
-    --> tests/resolution/fail/invalid-func-type-ref.wac:4:8
+    --> tests/resolution/fail/invalid-func-type-ref.wac:6:8
      |
-   4 |     x: x;
+   6 |     x: x;
      |        ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-use-alias.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-use-alias.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface a {
     type a = u32;
 }

--- a/crates/wac-parser/tests/resolution/fail/invalid-use-alias.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-use-alias.wac.result
@@ -1,5 +1,5 @@
-`b` was previously defined at tests/resolution/fail/invalid-use-alias.wac:6:10
-    --> tests/resolution/fail/invalid-use-alias.wac:7:17
+`b` was previously defined at tests/resolution/fail/invalid-use-alias.wac:8:10
+    --> tests/resolution/fail/invalid-use-alias.wac:9:17
      |
-   7 |     use a.{a as b};
+   9 |     use a.{a as b};
      |                 ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-use.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-use.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 interface a {

--- a/crates/wac-parser/tests/resolution/fail/invalid-use.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-use.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not an interface
-    --> tests/resolution/fail/invalid-use.wac:4:9
+    --> tests/resolution/fail/invalid-use.wac:6:9
      |
-   4 |     use x.{a};
+   6 |     use x.{a};
      |         ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-value-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-value-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface i {
 
 }

--- a/crates/wac-parser/tests/resolution/fail/invalid-value-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-value-type.wac.result
@@ -1,5 +1,5 @@
 `i` (interface) cannot be used as a value type
-    --> tests/resolution/fail/invalid-value-type.wac:5:18
+    --> tests/resolution/fail/invalid-value-type.wac:7:18
      |
-   5 | type x = func(i: i);
+   7 | type x = func(i: i);
      |                  ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-export.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 world w {

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-export.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not a function type or interface
-    --> tests/resolution/fail/invalid-world-export.wac:4:15
+    --> tests/resolution/fail/invalid-world-export.wac:6:15
      |
-   4 |     import x: x;
+   6 |     import x: x;
      |               ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-import.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-import.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 world w {

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-import.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not a function type or interface
-    --> tests/resolution/fail/invalid-world-import.wac:4:15
+    --> tests/resolution/fail/invalid-world-import.wac:6:15
      |
-   4 |     import x: x;
+   6 |     import x: x;
      |               ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-include.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-include.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = func();
 
 world w {

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-include.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-include.wac.result
@@ -1,5 +1,5 @@
 `x` (function type) is not a world
-    --> tests/resolution/fail/invalid-world-include.wac:4:13
+    --> tests/resolution/fail/invalid-world-include.wac:6:13
      |
-   4 |     include x;
+   6 |     include x;
      |             ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-interface-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-interface-export.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 world w {

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-interface-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-interface-export.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not an interface
-    --> tests/resolution/fail/invalid-world-interface-export.wac:4:12
+    --> tests/resolution/fail/invalid-world-interface-export.wac:6:12
      |
-   4 |     export x;
+   6 |     export x;
      |            ^

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-interface-import.wac
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-interface-import.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 type x = u32;
 
 world w {

--- a/crates/wac-parser/tests/resolution/fail/invalid-world-interface-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/invalid-world-interface-import.wac.result
@@ -1,5 +1,5 @@
 `x` (u32) is not an interface
-    --> tests/resolution/fail/invalid-world-interface-import.wac:4:12
+    --> tests/resolution/fail/invalid-world-interface-import.wac:6:12
      |
-   4 |     import x;
+   6 |     import x;
      |            ^

--- a/crates/wac-parser/tests/resolution/fail/mismatched-enum-cases.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-enum-cases.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     enum e {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-enum-cases.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-enum-cases.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-enum-cases.wac:9:23
+    --> tests/resolution/fail/mismatched-enum-cases.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-enum-count.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-enum-count.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     enum e {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-enum-count.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-enum-count.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-enum-count.wac:10:23
+    --> tests/resolution/fail/mismatched-enum-count.wac:12:23
      |
-  10 | let i = new foo:bar { x };
+  12 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-err-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-err-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> result<_, string>;
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-err-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-err-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-err-result-type.wac:5:23
+    --> tests/resolution/fail/mismatched-err-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-flags-count.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-flags-count.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     flags f {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-flags-count.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-flags-count.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-flags-count.wac:10:23
+    --> tests/resolution/fail/mismatched-flags-count.wac:12:23
      |
-  10 | let i = new foo:bar { x };
+  12 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-flags.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-flags.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     flags f {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-flags.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-flags.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-flags.wac:9:23
+    --> tests/resolution/fail/mismatched-flags.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-param-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-param-name.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func(b: u32);
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-param-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-param-name.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-func-param-name.wac:5:23
+    --> tests/resolution/fail/mismatched-func-param-name.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-param-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-param-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     resource r;
     f: func(r: string);

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-param-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-param-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-func-param-type.wac:6:23
+    --> tests/resolution/fail/mismatched-func-param-type.wac:8:23
      |
-   6 | let i = new foo:bar { x };
+   8 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-params.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-params.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func();
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-params.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-params.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-func-params.wac:5:23
+    --> tests/resolution/fail/mismatched-func-params.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-result-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-result-name.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> (a: string, c: u32);
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-result-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-result-name.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-func-result-name.wac:5:23
+    --> tests/resolution/fail/mismatched-func-result-name.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> (a: string, b: string);
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-func-result-type.wac:5:23
+    --> tests/resolution/fail/mismatched-func-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-scalar-result.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-scalar-result.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> string;
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-func-scalar-result.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-func-scalar-result.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-func-scalar-result.wac:5:23
+    --> tests/resolution/fail/mismatched-func-scalar-result.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-kind.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-kind.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     type x = u32;
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-kind.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-kind.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-kind.wac:5:23
+    --> tests/resolution/fail/mismatched-kind.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-list-element.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-list-element.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func(l: list<string>);
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-list-element.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-list-element.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-list-element.wac:5:23
+    --> tests/resolution/fail/mismatched-list-element.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-ok-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-ok-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> result<string>;
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-ok-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-ok-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-ok-result-type.wac:5:23
+    --> tests/resolution/fail/mismatched-ok-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-option.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-option.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func(o: option<u8>);
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-option.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-option.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-option.wac:5:23
+    --> tests/resolution/fail/mismatched-option.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-record-field-count.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-record-field-count.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     record r {
         a: u8,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-record-field-count.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-record-field-count.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-record-field-count.wac:10:23
+    --> tests/resolution/fail/mismatched-record-field-count.wac:12:23
      |
-  10 | let i = new foo:bar { x };
+  12 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-record-field-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-record-field-name.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     record r {
         a: u8,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-record-field-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-record-field-name.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-record-field-name.wac:9:23
+    --> tests/resolution/fail/mismatched-record-field-name.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-record-field-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-record-field-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     record r {
         a: u8,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-record-field-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-record-field-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-record-field-type.wac:9:23
+    --> tests/resolution/fail/mismatched-record-field-type.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-resource-types.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-resource-types.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     resource x;
     resource y;

--- a/crates/wac-parser/tests/resolution/fail/mismatched-resource-types.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-resource-types.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-resource-types.wac:7:23
+    --> tests/resolution/fail/mismatched-resource-types.wac:9:23
      |
-   7 | let i = new foo:bar { x };
+   9 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-tuple-size.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-tuple-size.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     type t = tuple<u8, string, tuple<u32>, u16>;
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-tuple-size.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-tuple-size.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-tuple-size.wac:5:23
+    --> tests/resolution/fail/mismatched-tuple-size.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-tuple-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-tuple-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     type t = tuple<u8, string, tuple<string>>;
 };

--- a/crates/wac-parser/tests/resolution/fail/mismatched-tuple-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-tuple-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-tuple-type.wac:5:23
+    --> tests/resolution/fail/mismatched-tuple-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-count.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-count.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     variant v {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-count.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-count.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-variant-case-count.wac:10:23
+    --> tests/resolution/fail/mismatched-variant-case-count.wac:12:23
      |
-  10 | let i = new foo:bar { x };
+  12 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-name.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     variant v {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-name.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-variant-case-name.wac:9:23
+    --> tests/resolution/fail/mismatched-variant-case-name.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     variant v {
         a,

--- a/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/mismatched-variant-case-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/mismatched-variant-case-type.wac:9:23
+    --> tests/resolution/fail/mismatched-variant-case-type.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-constructor.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-constructor.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     resource r;
     f: func(r: r);

--- a/crates/wac-parser/tests/resolution/fail/missing-constructor.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-constructor.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/missing-constructor.wac:6:23
+    --> tests/resolution/fail/missing-constructor.wac:8:23
      |
-   6 | let i = new foo:bar { x };
+   8 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-err-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-err-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> result;
 };

--- a/crates/wac-parser/tests/resolution/fail/missing-err-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-err-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/missing-err-result-type.wac:5:23
+    --> tests/resolution/fail/missing-err-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-interface-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-interface-export.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
 };
 

--- a/crates/wac-parser/tests/resolution/fail/missing-interface-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-interface-export.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/missing-interface-export.wac:4:23
+    --> tests/resolution/fail/missing-interface-export.wac:6:23
      |
-   4 | let i = new foo:bar { x };
+   6 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-method.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-method.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     resource r;
     f: func(r: r);

--- a/crates/wac-parser/tests/resolution/fail/missing-method.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-method.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/missing-method.wac:6:23
+    --> tests/resolution/fail/missing-method.wac:8:23
      |
-   6 | let i = new foo:bar { x };
+   8 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-ok-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-ok-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> result<_>;
 };

--- a/crates/wac-parser/tests/resolution/fail/missing-ok-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-ok-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/missing-ok-result-type.wac:5:23
+    --> tests/resolution/fail/missing-ok-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-static-method.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-static-method.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     resource r;
     f: func(r: r);

--- a/crates/wac-parser/tests/resolution/fail/missing-static-method.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-static-method.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/missing-static-method.wac:6:23
+    --> tests/resolution/fail/missing-static-method.wac:8:23
      |
-   6 | let i = new foo:bar { x };
+   8 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/missing-type-in-use.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-type-in-use.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface a {
 
 }

--- a/crates/wac-parser/tests/resolution/fail/missing-type-in-use.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-type-in-use.wac.result
@@ -1,5 +1,5 @@
 type `x` is not defined in interface `a`
-    --> tests/resolution/fail/missing-type-in-use.wac:6:12
+    --> tests/resolution/fail/missing-type-in-use.wac:8:12
      |
-   6 |     use a.{x};
+   8 |     use a.{x};
      |            ^

--- a/crates/wac-parser/tests/resolution/fail/missing-world-include-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-world-include-name.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w1 {
 
 }

--- a/crates/wac-parser/tests/resolution/fail/missing-world-include-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-world-include-name.wac.result
@@ -1,5 +1,5 @@
 world `w1` does not have an import or export named `a`
-    --> tests/resolution/fail/missing-world-include-name.wac:6:23
+    --> tests/resolution/fail/missing-world-include-name.wac:8:23
      |
-   6 |     include w1 with { a as b };
+   8 |     include w1 with { a as b };
      |                       ^

--- a/crates/wac-parser/tests/resolution/fail/no-err-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/no-err-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> result<_, string>;
 };

--- a/crates/wac-parser/tests/resolution/fail/no-err-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/no-err-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/no-err-result-type.wac:5:23
+    --> tests/resolution/fail/no-err-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/no-import.wac
+++ b/crates/wac-parser/tests/resolution/fail/no-import.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 import x: interface {};
 let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/no-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/no-import.wac.result
@@ -1,5 +1,5 @@
 component `foo:bar` has no import named `x`
-    --> tests/resolution/fail/no-import.wac:2:23
+    --> tests/resolution/fail/no-import.wac:4:23
      |
-   2 | let i = new foo:bar { x };
+   4 | let i = new foo:bar { x };
      |                       ^

--- a/crates/wac-parser/tests/resolution/fail/no-ok-result-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/no-ok-result-type.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     f: func() -> result<string>;
 };

--- a/crates/wac-parser/tests/resolution/fail/no-ok-result-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/no-ok-result-type.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/no-ok-result-type.wac:5:23
+    --> tests/resolution/fail/no-ok-result-type.wac:7:23
      |
-   5 | let i = new foo:bar { x };
+   7 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/package-invalid-wasm.wac
+++ b/crates/wac-parser/tests/resolution/fail/package-invalid-wasm.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 import foo: foo:bar/qux;

--- a/crates/wac-parser/tests/resolution/fail/package-invalid-wasm.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/package-invalid-wasm.wac.result
@@ -1,7 +1,7 @@
 failed to parse package `foo:bar`
-    --> tests/resolution/fail/package-invalid-wasm.wac:1:13
+    --> tests/resolution/fail/package-invalid-wasm.wac:3:13
      |
-   1 | import foo: foo:bar/qux;
+   3 | import foo: foo:bar/qux;
      |             ^-----^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/package-not-component.wac
+++ b/crates/wac-parser/tests/resolution/fail/package-not-component.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 import foo: foo:bar/qux;

--- a/crates/wac-parser/tests/resolution/fail/package-not-component.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/package-not-component.wac.result
@@ -1,7 +1,7 @@
 failed to parse package `foo:bar`
-    --> tests/resolution/fail/package-not-component.wac:1:13
+    --> tests/resolution/fail/package-not-component.wac:3:13
      |
-   1 | import foo: foo:bar/qux;
+   3 | import foo: foo:bar/qux;
      |             ^-----^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/package-not-wasm.wac
+++ b/crates/wac-parser/tests/resolution/fail/package-not-wasm.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 import foo: foo:bar/qux;

--- a/crates/wac-parser/tests/resolution/fail/package-not-wasm.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/package-not-wasm.wac.result
@@ -1,7 +1,7 @@
 failed to parse package `foo:bar`
-    --> tests/resolution/fail/package-not-wasm.wac:1:13
+    --> tests/resolution/fail/package-not-wasm.wac:3:13
      |
-   1 | import foo: foo:bar/qux;
+   3 | import foo: foo:bar/qux;
      |             ^-----^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/redefined-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/redefined-name.wac
@@ -1,2 +1,4 @@
+package test:comp;
+
 type x = u32;
 type x = string;

--- a/crates/wac-parser/tests/resolution/fail/redefined-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/redefined-name.wac.result
@@ -1,5 +1,5 @@
-`x` was previously defined at tests/resolution/fail/redefined-name.wac:1:6
-    --> tests/resolution/fail/redefined-name.wac:2:6
+`x` was previously defined at tests/resolution/fail/redefined-name.wac:3:6
+    --> tests/resolution/fail/redefined-name.wac:4:6
      |
-   2 | type x = string;
+   4 | type x = string;
      |      ^

--- a/crates/wac-parser/tests/resolution/fail/undefined-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/undefined-name.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 type x = x;

--- a/crates/wac-parser/tests/resolution/fail/undefined-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/undefined-name.wac.result
@@ -1,5 +1,5 @@
 undefined name `x`
-    --> tests/resolution/fail/undefined-name.wac:1:10
+    --> tests/resolution/fail/undefined-name.wac:3:10
      |
-   1 | type x = x;
+   3 | type x = x;
      |          ^

--- a/crates/wac-parser/tests/resolution/fail/unknown-package.wac
+++ b/crates/wac-parser/tests/resolution/fail/unknown-package.wac
@@ -1,1 +1,3 @@
+package test:comp;
+
 import foo: bar:baz/qux;

--- a/crates/wac-parser/tests/resolution/fail/unknown-package.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/unknown-package.wac.result
@@ -1,5 +1,5 @@
 unknown package `bar:baz`
-    --> tests/resolution/fail/unknown-package.wac:1:13
+    --> tests/resolution/fail/unknown-package.wac:3:13
      |
-   1 | import foo: bar:baz/qux;
+   3 | import foo: bar:baz/qux;
      |             ^-----^

--- a/crates/wac-parser/tests/resolution/fail/variant-case-typed.wac
+++ b/crates/wac-parser/tests/resolution/fail/variant-case-typed.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     variant v {
         a,

--- a/crates/wac-parser/tests/resolution/fail/variant-case-typed.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/variant-case-typed.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/variant-case-typed.wac:9:23
+    --> tests/resolution/fail/variant-case-typed.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/variant-case-untyped.wac
+++ b/crates/wac-parser/tests/resolution/fail/variant-case-untyped.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 import x: interface {
     variant v {
         a(string),

--- a/crates/wac-parser/tests/resolution/fail/variant-case-untyped.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/variant-case-untyped.wac.result
@@ -1,7 +1,7 @@
 mismatched instantiation argument `x`
-    --> tests/resolution/fail/variant-case-untyped.wac:9:23
+    --> tests/resolution/fail/variant-case-untyped.wac:11:23
      |
-   9 | let i = new foo:bar { x };
+  11 | let i = new foo:bar { x };
      |                       ^
 
 Caused by:

--- a/crates/wac-parser/tests/resolution/fail/world-include-conflict.wac
+++ b/crates/wac-parser/tests/resolution/fail/world-include-conflict.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w1 {
     export a: func();
 }

--- a/crates/wac-parser/tests/resolution/fail/world-include-conflict.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/world-include-conflict.wac.result
@@ -1,5 +1,5 @@
 export `a` from world `w1` conflicts with export of the same name in world `w2` (consider using a `with` clause to use a different name)
-    --> tests/resolution/fail/world-include-conflict.wac:6:13
+    --> tests/resolution/fail/world-include-conflict.wac:8:13
      |
-   6 |     include w1;
+   8 |     include w1;
      |             ^^

--- a/crates/wac-parser/tests/resolution/fail/world-include-with-conflict.wac
+++ b/crates/wac-parser/tests/resolution/fail/world-include-with-conflict.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w1 {
     export a: func();
 }

--- a/crates/wac-parser/tests/resolution/fail/world-include-with-conflict.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/world-include-with-conflict.wac.result
@@ -1,5 +1,5 @@
 export `x` from world `w1` conflicts with export of the same name in world `w2`
-    --> tests/resolution/fail/world-include-with-conflict.wac:6:28
+    --> tests/resolution/fail/world-include-with-conflict.wac:8:28
      |
-   6 |     include w1 with { a as x };
+   8 |     include w1 with { a as x };
      |                            ^

--- a/crates/wac-parser/tests/resolution/import.wac
+++ b/crates/wac-parser/tests/resolution/import.wac
@@ -1,3 +1,5 @@
+package test:comp@0.0.1-beta;
+
 /// Import by func type
 import a: func();
 

--- a/crates/wac-parser/tests/resolution/import.wac.result
+++ b/crates/wac-parser/tests/resolution/import.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "0.0.1-beta",
   "definitions": {
     "types": [],
     "resources": [],

--- a/crates/wac-parser/tests/resolution/let-statements.wac
+++ b/crates/wac-parser/tests/resolution/let-statements.wac
@@ -1,6 +1,8 @@
+package test:comp@1.0.0;
+
 import streams: wasi:io/streams;
 
-let i = new foo:bar { streams, baz: new foo:bar { streams, ... }.baz };
+let i = new foo:bar { streams, baz: new foo:bar@100.0.0 { streams, ... }.baz };
 
 export i.baz;
 export i with "i";

--- a/crates/wac-parser/tests/resolution/let-statements.wac.result
+++ b/crates/wac-parser/tests/resolution/let-statements.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "1.0.0",
   "definitions": {
     "types": [
       {

--- a/crates/wac-parser/tests/resolution/no-imports.wac
+++ b/crates/wac-parser/tests/resolution/no-imports.wac
@@ -1,3 +1,5 @@
+package test:comp@0.3.0;
+
 let i = new foo:bar {};
 
 export i with "i";

--- a/crates/wac-parser/tests/resolution/no-imports.wac.result
+++ b/crates/wac-parser/tests/resolution/no-imports.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "0.3.0",
   "definitions": {
     "types": [],
     "resources": [],

--- a/crates/wac-parser/tests/resolution/package-import.wac
+++ b/crates/wac-parser/tests/resolution/package-import.wac
@@ -1,3 +1,5 @@
+package test:comp@1.0.0;
+
 import i: foo:bar/i;
 
 export i;

--- a/crates/wac-parser/tests/resolution/package-import.wac.result
+++ b/crates/wac-parser/tests/resolution/package-import.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "1.0.0",
   "definitions": {
     "types": [
       {

--- a/crates/wac-parser/tests/resolution/package-use-item.wac
+++ b/crates/wac-parser/tests/resolution/package-use-item.wac
@@ -1,3 +1,5 @@
+package test:comp@0.0.1;
+
 interface i {
     use foo:bar/baz.{a, b, c};
 }

--- a/crates/wac-parser/tests/resolution/package-use-item.wac.result
+++ b/crates/wac-parser/tests/resolution/package-use-item.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "0.0.1",
   "definitions": {
     "types": [
       {
@@ -78,7 +79,7 @@
         "scope": null
       },
       {
-        "id": "test:test/i",
+        "id": "test:comp/i",
         "exports": {
           "a": {
             "use": {

--- a/crates/wac-parser/tests/resolution/package-world-include.wac
+++ b/crates/wac-parser/tests/resolution/package-world-include.wac
@@ -1,3 +1,5 @@
+package test:comp@1.2.3-prerelease;
+
 world w {
     include foo:bar/baz;
 }

--- a/crates/wac-parser/tests/resolution/package-world-include.wac.result
+++ b/crates/wac-parser/tests/resolution/package-world-include.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": "1.2.3-prerelease",
   "definitions": {
     "types": [
       {

--- a/crates/wac-parser/tests/resolution/package-world-item.wac
+++ b/crates/wac-parser/tests/resolution/package-world-item.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 world w {
     import foo:bar/baz;
     export bar:baz/qux;

--- a/crates/wac-parser/tests/resolution/package-world-item.wac.result
+++ b/crates/wac-parser/tests/resolution/package-world-item.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": null,
   "definitions": {
     "types": [
       {

--- a/crates/wac-parser/tests/resolution/resource.wac
+++ b/crates/wac-parser/tests/resolution/resource.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 interface foo {
     resource x;
     type f = func(x: borrow<x>);

--- a/crates/wac-parser/tests/resolution/resource.wac.result
+++ b/crates/wac-parser/tests/resolution/resource.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": null,
   "definitions": {
     "types": [
       {
@@ -22,7 +23,7 @@
     ],
     "interfaces": [
       {
-        "id": "test:test/foo",
+        "id": "test:comp/foo",
         "exports": {
           "x": {
             "kind": {

--- a/crates/wac-parser/tests/resolution/types.wac
+++ b/crates/wac-parser/tests/resolution/types.wac
@@ -1,3 +1,5 @@
+package test:comp;
+
 /// Defining an interface
 interface i {
     /// Type alias a

--- a/crates/wac-parser/tests/resolution/types.wac.result
+++ b/crates/wac-parser/tests/resolution/types.wac.result
@@ -1,5 +1,6 @@
 {
-  "package": "test:test",
+  "package": "test:comp",
+  "version": null,
   "definitions": {
     "types": [
       {
@@ -115,7 +116,7 @@
     ],
     "interfaces": [
       {
-        "id": "test:test/i",
+        "id": "test:comp/i",
         "exports": {
           "a": {
             "kind": {
@@ -145,7 +146,7 @@
         "scope": 1
       },
       {
-        "id": "test:test/i2",
+        "id": "test:comp/i2",
         "exports": {
           "r": {
             "use": {
@@ -256,7 +257,7 @@
               "func": 3
             }
           },
-          "test:test/i": {
+          "test:comp/i": {
             "kind": {
               "instance": 0
             }
@@ -275,7 +276,7 @@
               }
             }
           },
-          "test:test/i2": {
+          "test:comp/i2": {
             "kind": {
               "instance": 1
             }
@@ -307,7 +308,7 @@
               "func": 3
             }
           },
-          "test:test/i": {
+          "test:comp/i": {
             "kind": {
               "instance": 0
             }
@@ -333,7 +334,7 @@
               }
             }
           },
-          "test:test/i2": {
+          "test:comp/i2": {
             "kind": {
               "instance": 1
             }

--- a/src/commands/parse.rs
+++ b/src/commands/parse.rs
@@ -33,10 +33,6 @@ struct Output<'a> {
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
 pub struct ParseCommand {
-    /// The package being parsed.
-    #[clap(long, short, value_name = "PACKAGE")]
-    pub package: String,
-
     /// The directory to search for package dependencies.
     #[clap(long, value_name = "PATH", default_value = "deps")]
     pub deps_dir: PathBuf,
@@ -66,7 +62,6 @@ impl ParseCommand {
         })?;
         let resolved = ResolvedDocument::new(
             &document,
-            self.package,
             Some(Box::new(FileSystemPackageResolver::new(
                 self.deps_dir,
                 self.deps.into_iter().collect(),


### PR DESCRIPTION
This PR adds a `package` directive to the grammar to match what is present
in WIT.

As a result, the `--package` command line argument to the `parse` command was
removed.

Additionally, lexing of semver is relaxed so that invalid semantic versions can
be detected when building the AST.