### PR TITLE
Fix lexing on Windows.

### DIFF
--- a/crates/wac-parser/src/lexer.rs
+++ b/crates/wac-parser/src/lexer.rs
@@ -145,7 +145,7 @@ fn detect_invalid_input(source: &str) -> Result<(), (Error, Span)> {
 /// Represents a WAC token.
 #[derive(Logos, Debug, Clone, Copy, PartialEq, Eq)]
 #[logos(error = Error)]
-#[logos(skip r"[ \t\n\f]+")]
+#[logos(skip r"[ \t\r\n\f]+")]
 #[logos(subpattern id = r"%?[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*")]
 #[logos(subpattern package_name = r"(?&id)(:(?&id))+")]
 #[logos(subpattern semver = r"[0-9a-zA-Z-\.\+]+")]

--- a/crates/wac-parser/tests/resolution/fail/windows-file.wac
+++ b/crates/wac-parser/tests/resolution/fail/windows-file.wac
@@ -1,0 +1,4 @@
+package foo:bar;
+
+import x: func();
+import x: func();

--- a/crates/wac-parser/tests/resolution/fail/windows-file.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/windows-file.wac.result
@@ -1,0 +1,5 @@
+duplicate import `x`
+    --> tests/resolution/fail/windows-file.wac:4:8
+     |
+   4 | import x: func();
+     |        ^


### PR DESCRIPTION
Accidentally forgot to skip `\r` as whitespace, so lexing for files saved on Windows didn't work.

Added a file with `\r\n` endings to ensure both the lexing and the reporting spans are correct.