### PR TITLE
Use `as` in import and export statements.

### DIFF
--- a/crates/wac-parser/src/ast.rs
+++ b/crates/wac-parser/src/ast.rs
@@ -489,7 +489,7 @@ world w {
 /// Doc comment #9!
 let x = new foo:bar { };
 /// Doc comment #10!
-export x with "foo";
+export x as "foo";
 "#,
             r#"/// Doc comment for the package!
 package test:foo:bar@1.0.0;
@@ -524,7 +524,7 @@ world w {
 let x = new foo:bar {};
 
 /// Doc comment #10!
-export x with "foo";
+export x as "foo";
 "#,
         )
         .unwrap()

--- a/crates/wac-parser/src/ast/export.rs
+++ b/crates/wac-parser/src/ast/export.rs
@@ -13,8 +13,8 @@ pub struct ExportStatement<'a> {
     pub docs: Vec<DocComment<'a>>,
     /// The span of the export keyword.
     pub span: SourceSpan,
-    /// The optional `with` string.
-    pub with: Option<super::String<'a>>,
+    /// The optional name to use for the export.
+    pub name: Option<super::String<'a>>,
     /// The expression to export.
     pub expr: Expr<'a>,
 }
@@ -24,13 +24,13 @@ impl<'a> Parse<'a> for ExportStatement<'a> {
         let docs = Parse::parse(lexer)?;
         let span = parse_token(lexer, Token::ExportKeyword)?;
         let expr = Parse::parse(lexer)?;
-        let with = parse_optional(lexer, Token::WithKeyword, Parse::parse)?;
+        let name = parse_optional(lexer, Token::AsKeyword, Parse::parse)?;
         parse_token(lexer, Token::Semicolon)?;
         Ok(Self {
             docs,
             span,
             expr,
-            with,
+            name,
         })
     }
 }
@@ -53,8 +53,8 @@ mod test {
         )
         .unwrap();
         roundtrip(
-            "package foo:bar; export foo.%with with \"foo\";",
-            "package foo:bar;\n\nexport foo.%with with \"foo\";\n",
+            "package foo:bar; export foo.%with as \"foo\";",
+            "package foo:bar;\n\nexport foo.%with as \"foo\";\n",
         )
         .unwrap();
         roundtrip(
@@ -63,8 +63,8 @@ mod test {
         )
         .unwrap();
         roundtrip(
-            "package foo:bar; export y.x.z with \"baz\";",
-            "package foo:bar;\n\nexport y.x.z with \"baz\";\n",
+            "package foo:bar; export y.x.z as \"baz\";",
+            "package foo:bar;\n\nexport y.x.z as \"baz\";\n",
         )
         .unwrap();
         roundtrip(
@@ -73,8 +73,8 @@ mod test {
         )
         .unwrap();
         roundtrip(
-            "package foo:bar; export y[\"x\"][\"z\"]  with    \"x\";",
-            "package foo:bar;\n\nexport y[\"x\"][\"z\"] with \"x\";\n",
+            "package foo:bar; export y[\"x\"][\"z\"]  as    \"x\";",
+            "package foo:bar;\n\nexport y[\"x\"][\"z\"] as \"x\";\n",
         )
         .unwrap();
         roundtrip(
@@ -83,8 +83,8 @@ mod test {
         )
         .unwrap();
         roundtrip(
-            "package foo:bar; export foo[\"bar\"].baz[\"qux\"] with \"qux\";",
-            "package foo:bar;\n\nexport foo[\"bar\"].baz[\"qux\"] with \"qux\";\n",
+            "package foo:bar; export foo[\"bar\"].baz[\"qux\"] as \"qux\";",
+            "package foo:bar;\n\nexport foo[\"bar\"].baz[\"qux\"] as \"qux\";\n",
         )
         .unwrap();
 
@@ -101,8 +101,8 @@ mod test {
         .unwrap();
 
         roundtrip(
-            "package foo:bar; export new foo:bar {}  /* foo */ with     \"foo\";",
-            "package foo:bar;\n\nexport new foo:bar {} with \"foo\";\n",
+            "package foo:bar; export new foo:bar {}  /* foo */ as     \"foo\";",
+            "package foo:bar;\n\nexport new foo:bar {} as \"foo\";\n",
         )
         .unwrap();
 

--- a/crates/wac-parser/src/ast/import.rs
+++ b/crates/wac-parser/src/ast/import.rs
@@ -15,8 +15,8 @@ pub struct ImportStatement<'a> {
     pub docs: Vec<DocComment<'a>>,
     /// The identifier of the imported item.
     pub id: Ident<'a>,
-    /// The optional `with` string.
-    pub with: Option<super::String<'a>>,
+    /// The optional import name.
+    pub name: Option<super::String<'a>>,
     /// The type of the imported item.
     pub ty: ImportType<'a>,
 }
@@ -26,11 +26,11 @@ impl<'a> Parse<'a> for ImportStatement<'a> {
         let docs = Parse::parse(lexer)?;
         parse_token(lexer, Token::ImportKeyword)?;
         let id = Parse::parse(lexer)?;
-        let with = parse_optional(lexer, Token::WithKeyword, Parse::parse)?;
+        let name = parse_optional(lexer, Token::AsKeyword, Parse::parse)?;
         parse_token(lexer, Token::Colon)?;
         let ty = Parse::parse(lexer)?;
         parse_token(lexer, Token::Semicolon)?;
-        Ok(Self { docs, id, with, ty })
+        Ok(Self { docs, id, name, ty })
     }
 }
 
@@ -195,8 +195,8 @@ mod test {
         .unwrap();
 
         roundtrip(
-            "package foo:bar; import x with \"y\": foo:bar:baz/qux/jam@1.2.3-preview+abc;",
-            "package foo:bar;\n\nimport x with \"y\": foo:bar:baz/qux/jam@1.2.3-preview+abc;\n",
+            "package foo:bar; import x as \"y\": foo:bar:baz/qux/jam@1.2.3-preview+abc;",
+            "package foo:bar;\n\nimport x as \"y\": foo:bar:baz/qux/jam@1.2.3-preview+abc;\n",
         )
         .unwrap();
     }
@@ -210,8 +210,8 @@ mod test {
         .unwrap();
 
         roundtrip(
-            "package foo:bar; import x with \"foo\": func(x: string) -> string;",
-            "package foo:bar;\n\nimport x with \"foo\": func(x: string) -> string;\n",
+            "package foo:bar; import x as \"foo\": func(x: string) -> string;",
+            "package foo:bar;\n\nimport x as \"foo\": func(x: string) -> string;\n",
         )
         .unwrap();
     }
@@ -225,8 +225,8 @@ mod test {
         .unwrap();
 
         roundtrip(
-            "package foo:bar; import x with \"foo\": interface { x: func(x: string) -> string; };",
-            "package foo:bar;\n\nimport x with \"foo\": interface {\n    x: func(x: string) -> string;\n};\n",
+            "package foo:bar; import x as \"foo\": interface { x: func(x: string) -> string; };",
+            "package foo:bar;\n\nimport x as \"foo\": interface {\n    x: func(x: string) -> string;\n};\n",
         )
         .unwrap();
     }
@@ -240,8 +240,8 @@ mod test {
         .unwrap();
 
         roundtrip(
-            "package foo:bar; import x /*foo */ with    \"foo\": y;",
-            "package foo:bar;\n\nimport x with \"foo\": y;\n",
+            "package foo:bar; import x /*foo */ as    \"foo\": y;",
+            "package foo:bar;\n\nimport x as \"foo\": y;\n",
         )
         .unwrap();
     }

--- a/crates/wac-parser/src/ast/printer.rs
+++ b/crates/wac-parser/src/ast/printer.rs
@@ -83,8 +83,8 @@ impl<'a, W: Write> DocumentPrinter<'a, W> {
             id = self.source(statement.id.span)
         )?;
 
-        if let Some(with) = &statement.with {
-            write!(self.writer, " with {with}", with = self.source(with.span))?;
+        if let Some(name) = &statement.name {
+            write!(self.writer, " as {name}", name = self.source(name.span))?;
         }
 
         write!(self.writer, ": ")?;
@@ -751,8 +751,8 @@ impl<'a, W: Write> DocumentPrinter<'a, W> {
         write!(self.writer, "export ")?;
         self.expr(&stmt.expr)?;
 
-        if let Some(with) = &stmt.with {
-            write!(self.writer, " with {with}", with = self.source(with.span))?;
+        if let Some(name) = &stmt.name {
+            write!(self.writer, " as {name}", name = self.source(name.span))?;
         }
 
         write!(self.writer, ";")

--- a/crates/wac-parser/src/resolution/ast.rs
+++ b/crates/wac-parser/src/resolution/ast.rs
@@ -229,8 +229,8 @@ impl<'a> AstResolver<'a> {
             _ => kind,
         };
 
-        let (name, span) = if let Some(with) = stmt.with {
-            (with.value, with.span)
+        let (name, span) = if let Some(name) = stmt.name {
+            (name.value, name.span)
         } else {
             // If the item is an instance with an id, use the id
             if let ItemKind::Instance(id) = kind {
@@ -348,7 +348,7 @@ impl<'a> AstResolver<'a> {
     ) -> ResolutionResult<()> {
         log::debug!("resolving export statement");
         let item = self.expr(state, &stmt.expr)?;
-        let (name, span) = if let Some(name) = stmt.with {
+        let (name, span) = if let Some(name) = stmt.name {
             (name.value, name.span)
         } else {
             (
@@ -397,10 +397,10 @@ impl<'a> AstResolver<'a> {
                     kind: definition.kind.as_str(&self.definitions).to_string(),
                     span,
                     definition: prev_span,
-                    help: if stmt.with.is_some() {
+                    help: if stmt.name.is_some() {
                         None
                     } else {
-                        Some("consider using a `with` clause to use a different name".into())
+                        Some("consider using an `as` clause to use a different name".into())
                     },
                 });
             }

--- a/crates/wac-parser/tests/parser/export.wac
+++ b/crates/wac-parser/tests/parser/export.wac
@@ -7,4 +7,4 @@ export e;
 export e["foo"];
 
 /// Export an alias of an item with a different name
-export e["foo"] with "bar";
+export e["foo"] as "bar";

--- a/crates/wac-parser/tests/parser/export.wac.result
+++ b/crates/wac-parser/tests/parser/export.wac.result
@@ -25,7 +25,7 @@
           "offset": 54,
           "length": 6
         },
-        "with": null,
+        "name": null,
         "expr": {
           "primary": {
             "ident": {
@@ -55,7 +55,7 @@
           "offset": 111,
           "length": 6
         },
-        "with": null,
+        "name": null,
         "expr": {
           "primary": {
             "ident": {
@@ -101,10 +101,10 @@
           "offset": 182,
           "length": 6
         },
-        "with": {
+        "name": {
           "value": "bar",
           "span": {
-            "offset": 203,
+            "offset": 201,
             "length": 5
           }
         },

--- a/crates/wac-parser/tests/parser/import.wac
+++ b/crates/wac-parser/tests/parser/import.wac
@@ -10,7 +10,7 @@ import b: x;
 import c: foo:bar/baz;
 
 /// Import by func type with kebab name 
-import d with "hello-world": func(name: string);
+import d as "hello-world": func(name: string);
 
 /// Import by inline interface
 import e: interface {

--- a/crates/wac-parser/tests/parser/import.wac.result
+++ b/crates/wac-parser/tests/parser/import.wac.result
@@ -28,7 +28,7 @@
             "length": 1
           }
         },
-        "with": null,
+        "name": null,
         "ty": {
           "func": {
             "params": [],
@@ -55,7 +55,7 @@
             "length": 1
           }
         },
-        "with": null,
+        "name": null,
         "ty": {
           "ident": {
             "string": "x",
@@ -85,7 +85,7 @@
             "length": 1
           }
         },
-        "with": null,
+        "name": null,
         "ty": {
           "package": {
             "span": {
@@ -118,10 +118,10 @@
             "length": 1
           }
         },
-        "with": {
+        "name": {
           "value": "hello-world",
           "span": {
-            "offset": 203,
+            "offset": 201,
             "length": 13
           }
         },
@@ -132,13 +132,13 @@
                 "id": {
                   "string": "name",
                   "span": {
-                    "offset": 223,
+                    "offset": 221,
                     "length": 4
                   }
                 },
                 "ty": {
                   "string": {
-                    "offset": 229,
+                    "offset": 227,
                     "length": 6
                   }
                 }
@@ -155,7 +155,7 @@
           {
             "comment": "Import by inline interface",
             "span": {
-              "offset": 239,
+              "offset": 237,
               "length": 30
             }
           }
@@ -163,11 +163,11 @@
         "id": {
           "string": "e",
           "span": {
-            "offset": 277,
+            "offset": 275,
             "length": 1
           }
         },
-        "with": null,
+        "name": null,
         "ty": {
           "interface": {
             "items": [
@@ -177,7 +177,7 @@
                   "id": {
                     "string": "x",
                     "span": {
-                      "offset": 296,
+                      "offset": 294,
                       "length": 1
                     }
                   },
@@ -200,7 +200,7 @@
           {
             "comment": "Import by package path with version",
             "span": {
-              "offset": 311,
+              "offset": 309,
               "length": 39
             }
           }
@@ -208,15 +208,15 @@
         "id": {
           "string": "f",
           "span": {
-            "offset": 358,
+            "offset": 356,
             "length": 1
           }
         },
-        "with": null,
+        "name": null,
         "ty": {
           "package": {
             "span": {
-              "offset": 361,
+              "offset": 359,
               "length": 17
             },
             "string": "foo:bar/baz@1.0.0",

--- a/crates/wac-parser/tests/resolution/alias.wac
+++ b/crates/wac-parser/tests/resolution/alias.wac
@@ -6,6 +6,6 @@ type b = string;
 
 type c = func();
 
-export a with "a2";
-export b with "b2";
-export c with "c2";
+export a as "a2";
+export b as "b2";
+export c as "c2";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac
@@ -1,6 +1,6 @@
 package test:comp;
 
-import f with "x": func();
+import f as "x": func();
 
 type x = u32;
 

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-alias.wac.result
@@ -11,4 +11,4 @@ failed to resolve document
    · ───┬──
    ·    ╰── conflicting export of `x`
    ╰────
-  help: consider using a `with` clause to use a different name
+  help: consider using an `as` clause to use a different name

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac
@@ -6,4 +6,4 @@ interface foo {
 
 }
 
-export f with "foo";
+export f as "foo";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-interface.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × export `foo` conflicts with interface definition
-   ╭─[tests/resolution/fail/export-conflict-interface.wac:9:15]
+   ╭─[tests/resolution/fail/export-conflict-interface.wac:9:13]
  4 │ 
  5 │ interface foo {
    ·           ─┬─
@@ -9,7 +9,7 @@ failed to resolve document
  6 │ 
  7 │ }
  8 │ 
- 9 │ export f with "foo";
-   ·               ──┬──
-   ·                 ╰── conflicting export of `foo`
+ 9 │ export f as "foo";
+   ·             ──┬──
+   ·               ╰── conflicting export of `foo`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac
@@ -1,9 +1,9 @@
 package test:comp;
 
-import f with "x": func();
+import f as "x": func();
 
 record x {
     a: u32
 }
 
-export f with "x";
+export f as "x";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-type.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × export `x` conflicts with record definition
-   ╭─[tests/resolution/fail/export-conflict-type.wac:9:15]
+   ╭─[tests/resolution/fail/export-conflict-type.wac:9:13]
  4 │ 
  5 │ record x {
    ·        ┬
@@ -9,7 +9,7 @@ failed to resolve document
  6 │     a: u32
  7 │ }
  8 │ 
- 9 │ export f with "x";
-   ·               ─┬─
-   ·                ╰── conflicting export of `x`
+ 9 │ export f as "x";
+   ·             ─┬─
+   ·              ╰── conflicting export of `x`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac
@@ -6,4 +6,4 @@ world foo {
 
 }
 
-export f with "foo";
+export f as "foo";

--- a/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-conflict-world.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × export `foo` conflicts with world definition
-   ╭─[tests/resolution/fail/export-conflict-world.wac:9:15]
+   ╭─[tests/resolution/fail/export-conflict-world.wac:9:13]
  4 │ 
  5 │ world foo {
    ·       ─┬─
@@ -9,7 +9,7 @@ failed to resolve document
  6 │ 
  7 │ }
  8 │ 
- 9 │ export f with "foo";
-   ·               ──┬──
-   ·                 ╰── conflicting export of `foo`
+ 9 │ export f as "foo";
+   ·             ──┬──
+   ·               ╰── conflicting export of `foo`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-dep-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-dep-name.wac
@@ -1,4 +1,4 @@
 package test:comp;
 
 import f: func();
-export f with "locked-dep=<foo:bar>";
+export f as "locked-dep=<foo:bar>";

--- a/crates/wac-parser/tests/resolution/fail/export-dep-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-dep-name.wac.result
@@ -2,9 +2,9 @@ failed to resolve document
 
   × export name `locked-dep=<foo:bar>` is not valid
   ╰─▶ export name cannot be a hash, url, or dependency
-   ╭─[tests/resolution/fail/export-dep-name.wac:4:15]
+   ╭─[tests/resolution/fail/export-dep-name.wac:4:13]
  3 │ import f: func();
- 4 │ export f with "locked-dep=<foo:bar>";
-   ·               ───────────┬──────────
-   ·                          ╰── invalid name `locked-dep=<foo:bar>`
+ 4 │ export f as "locked-dep=<foo:bar>";
+   ·             ───────────┬──────────
+   ·                        ╰── invalid name `locked-dep=<foo:bar>`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac
@@ -1,5 +1,5 @@
 package test:comp;
 
 import f: func();
-export f with "x";
-export f with "x";
+export f as "x";
+export f as "x";

--- a/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-duplicate-name.wac.result
@@ -1,12 +1,12 @@
 failed to resolve document
 
   × duplicate export `x`
-   ╭─[tests/resolution/fail/export-duplicate-name.wac:5:15]
+   ╭─[tests/resolution/fail/export-duplicate-name.wac:5:13]
  3 │ import f: func();
- 4 │ export f with "x";
-   ·               ─┬─
-   ·                ╰── previous export here
- 5 │ export f with "x";
-   ·               ─┬─
-   ·                ╰── duplicate export name `x`
+ 4 │ export f as "x";
+   ·             ─┬─
+   ·              ╰── previous export here
+ 5 │ export f as "x";
+   ·             ─┬─
+   ·              ╰── duplicate export name `x`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-hash-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-hash-name.wac
@@ -1,4 +1,4 @@
 package test:comp;
 
 import f: func();
-export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";
+export f as "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";

--- a/crates/wac-parser/tests/resolution/fail/export-hash-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-hash-name.wac.result
@@ -2,9 +2,9 @@ failed to resolve document
 
   × export name `integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>` is not valid
   ╰─▶ export name cannot be a hash, url, or dependency
-   ╭─[tests/resolution/fail/export-hash-name.wac:4:15]
+   ╭─[tests/resolution/fail/export-hash-name.wac:4:13]
  3 │ import f: func();
- 4 │ export f with "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";
-   ·               ──────────────────────────────────────────┬──────────────────────────────────────────
-   ·                                                         ╰── invalid name `integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>`
+ 4 │ export f as "integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>";
+   ·             ──────────────────────────────────────────┬──────────────────────────────────────────
+   ·                                                       ╰── invalid name `integrity=<sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac
@@ -1,4 +1,4 @@
 package test:comp;
 
 import f: func();
-export f with "INVALID!";
+export f as "INVALID!";

--- a/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-invalid-name.wac.result
@@ -2,9 +2,9 @@ failed to resolve document
 
   × export name `INVALID!` is not valid
   ╰─▶ `INVALID!` is not in kebab case
-   ╭─[tests/resolution/fail/export-invalid-name.wac:4:15]
+   ╭─[tests/resolution/fail/export-invalid-name.wac:4:13]
  3 │ import f: func();
- 4 │ export f with "INVALID!";
-   ·               ─────┬────
-   ·                    ╰── invalid name `INVALID!`
+ 4 │ export f as "INVALID!";
+   ·             ─────┬────
+   ·                  ╰── invalid name `INVALID!`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/export-url-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/export-url-name.wac
@@ -1,4 +1,4 @@
 package test:comp;
 
 import f: func();
-export f with "url=<https://example.com/foo>";
+export f as "url=<https://example.com/foo>";

--- a/crates/wac-parser/tests/resolution/fail/export-url-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/export-url-name.wac.result
@@ -2,9 +2,9 @@ failed to resolve document
 
   × export name `url=<https://example.com/foo>` is not valid
   ╰─▶ export name cannot be a hash, url, or dependency
-   ╭─[tests/resolution/fail/export-url-name.wac:4:15]
+   ╭─[tests/resolution/fail/export-url-name.wac:4:13]
  3 │ import f: func();
- 4 │ export f with "url=<https://example.com/foo>";
-   ·               ───────────────┬───────────────
-   ·                              ╰── invalid name `url=<https://example.com/foo>`
+ 4 │ export f as "url=<https://example.com/foo>";
+   ·             ───────────────┬───────────────
+   ·                            ╰── invalid name `url=<https://example.com/foo>`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac
@@ -1,4 +1,4 @@
 package test:comp;
 
-import x with "foo": func();
-import y with "foo": interface {};
+import x as "foo": func();
+import y as "foo": interface {};

--- a/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-duplicate-name.wac.result
@@ -1,12 +1,12 @@
 failed to resolve document
 
   × duplicate import `foo`
-   ╭─[tests/resolution/fail/import-duplicate-name.wac:4:15]
+   ╭─[tests/resolution/fail/import-duplicate-name.wac:4:13]
  2 │ 
- 3 │ import x with "foo": func();
-   ·               ──┬──
-   ·                 ╰── previous import here
- 4 │ import y with "foo": interface {};
-   ·               ──┬──
-   ·                 ╰── duplicate import name `foo`
+ 3 │ import x as "foo": func();
+   ·             ──┬──
+   ·               ╰── previous import here
+ 4 │ import y as "foo": interface {};
+   ·             ──┬──
+   ·               ╰── duplicate import name `foo`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac
@@ -1,3 +1,3 @@
 package test:comp;
 
-import x with "NOT-VALID-NAME!": func();
+import x as "NOT-VALID-NAME!": func();

--- a/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-invalid-name.wac.result
@@ -2,9 +2,9 @@ failed to resolve document
 
   × import name `NOT-VALID-NAME!` is not valid
   ╰─▶ `NOT-VALID-NAME!` is not in kebab case
-   ╭─[tests/resolution/fail/import-invalid-name.wac:3:15]
+   ╭─[tests/resolution/fail/import-invalid-name.wac:3:13]
  2 │ 
- 3 │ import x with "NOT-VALID-NAME!": func();
-   ·               ────────┬────────
-   ·                       ╰── invalid name `NOT-VALID-NAME!`
+ 3 │ import x as "NOT-VALID-NAME!": func();
+   ·             ────────┬────────
+   ·                     ╰── invalid name `NOT-VALID-NAME!`
    ╰────

--- a/crates/wac-parser/tests/resolution/import.wac
+++ b/crates/wac-parser/tests/resolution/import.wac
@@ -11,7 +11,7 @@ import b: x;
 //import c: foo:bar/baz;
 
 /// Import by func type with kebab name 
-import d with "hello-world": func(name: string);
+import d as "hello-world": func(name: string);
 
 /// Import by inline interface
 import e: interface {
@@ -22,5 +22,5 @@ import e: interface {
 import f: foo:bar/baz;
 
 export d;
-export e with "e";
+export e as "e";
 export f;

--- a/crates/wac-parser/tests/resolution/let-statements.wac
+++ b/crates/wac-parser/tests/resolution/let-statements.wac
@@ -5,4 +5,4 @@ import streams: wasi:io/streams;
 let i = new foo:bar { streams, baz: new foo:bar { streams, ... }.baz };
 
 export i.baz;
-export i with "i";
+export i as "i";

--- a/crates/wac-parser/tests/resolution/no-imports.wac
+++ b/crates/wac-parser/tests/resolution/no-imports.wac
@@ -2,4 +2,4 @@ package test:comp@0.3.0;
 
 let i = new foo:bar {};
 
-export i with "i";
+export i as "i";


### PR DESCRIPTION
This PR changes the use of the "with" keyword to the "as" keyword in import and export statements.

Partial fix for #10.