### PR TITLE
Fix span reported with "duplicate import" errors.

### DIFF
--- a/crates/wac-parser/src/resolution.rs
+++ b/crates/wac-parser/src/resolution.rs
@@ -646,6 +646,9 @@ pub enum Error {
         /// The span where the error occurred.
         #[label("previous {kind} here")]
         previous: SourceSpan,
+        /// The help of the error.
+        #[help]
+        help: Option<String>,
     },
     /// An invalid extern name was encountered.
     #[error("{kind} name `{name}` is not valid")]

--- a/crates/wac-parser/tests/resolution/fail/import-id-span.wac
+++ b/crates/wac-parser/tests/resolution/fail/import-id-span.wac
@@ -1,0 +1,5 @@
+package test:comp;
+
+import env-foo: wasi:cli/environment;
+
+import env-bar: wasi:cli/environment;

--- a/crates/wac-parser/tests/resolution/fail/import-id-span.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/import-id-span.wac.result
@@ -1,0 +1,14 @@
+failed to resolve document
+
+  × duplicate import `wasi:cli/environment`
+   ╭─[tests/resolution/fail/import-id-span.wac:5:17]
+ 2 │ 
+ 3 │ import env-foo: wasi:cli/environment;
+   ·                 ──────────┬─────────
+   ·                           ╰── previous import here
+ 4 │ 
+ 5 │ import env-bar: wasi:cli/environment;
+   ·                 ──────────┬─────────
+   ·                           ╰── duplicate import name `wasi:cli/environment`
+   ╰────
+  help: consider using an `as` clause to use a different name

--- a/crates/wac-parser/tests/resolution/fail/import-id-span/wasi/cli/package.wit
+++ b/crates/wac-parser/tests/resolution/fail/import-id-span/wasi/cli/package.wit
@@ -1,0 +1,4 @@
+package wasi:cli;
+
+interface environment {
+}

--- a/crates/wac-parser/tests/resolution/fail/windows-file.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/windows-file.wac.result
@@ -10,3 +10,4 @@ failed to resolve document
    ·        ┬
    ·        ╰── duplicate import name `x`
    ╰────
+  help: consider using an `as` clause to use a different name


### PR DESCRIPTION
When the imported item was an interface by package path, the span of the import was for the local identifier and not for the package path.

Fixes #15.