### PR TITLE
Fix merge of disjoint interfaces.

### DIFF
--- a/crates/wac-parser/src/resolution/encoding.rs
+++ b/crates/wac-parser/src/resolution/encoding.rs
@@ -620,7 +620,17 @@ impl<'a> TypeEncoder<'a> {
         // Otherwise, export all exports
         for (name, kind) in &interface.exports {
             match kind {
-                ItemKind::Type(_) | ItemKind::Resource(_) => {
+                ItemKind::Type(ty) => {
+                    let index = self.export(state, name, *kind)?;
+
+                    // Map the encoded type index to any remapped types.
+                    if let Some(prev) = interface.remapped_types.get(ty) {
+                        for ty in prev {
+                            state.current.type_indexes.insert(*ty, index);
+                        }
+                    }
+                }
+                ItemKind::Resource(_) => {
                     self.export(state, name, *kind)?;
                 }
                 _ => {

--- a/crates/wac-parser/src/resolution/package.rs
+++ b/crates/wac-parser/src/resolution/package.rs
@@ -364,6 +364,7 @@ impl<'a> TypeConverter<'a> {
         let instance_ty = &types[id];
         let id = self.definitions.interfaces.alloc(Interface {
             id: name.and_then(|n| n.contains(':').then(|| n.to_owned())),
+            remapped_types: Default::default(),
             uses: Default::default(),
             exports: IndexMap::with_capacity(instance_ty.exports.len()),
         });

--- a/crates/wac-parser/src/resolution/types.rs
+++ b/crates/wac-parser/src/resolution/types.rs
@@ -387,6 +387,15 @@ pub struct Interface {
     ///
     /// This may be `None` for inline interfaces.
     pub id: Option<String>,
+    /// Represents a remapping of types that may occur when an interface is merged.
+    ///
+    /// The map is from the type present in this interface to a set of types
+    /// originating from the merged interfaces.
+    ///
+    /// Encoding uses this map to populate the encoded type index map for the
+    /// original types.
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub remapped_types: IndexMap<Type, IndexSet<Type>>,
     /// A map from used interface to set of used type export indexes.
     #[serde(serialize_with = "serialize_id_key_map")]
     pub uses: IndexMap<InterfaceId, IndexSet<usize>>,

--- a/crates/wac-parser/src/resolution/types.rs
+++ b/crates/wac-parser/src/resolution/types.rs
@@ -394,7 +394,7 @@ pub struct Interface {
     ///
     /// Encoding uses this map to populate the encoded type index map for the
     /// original types.
-    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    #[serde(skip)]
     pub remapped_types: IndexMap<Type, IndexSet<Type>>,
     /// A map from used interface to set of used type export indexes.
     #[serde(serialize_with = "serialize_id_key_map")]

--- a/crates/wac-parser/tests/encoding/merged-functions.wac
+++ b/crates/wac-parser/tests/encoding/merged-functions.wac
@@ -1,0 +1,9 @@
+package test:comp;
+
+let a = new foo:bar {
+    ...
+};
+
+let b = new foo:baz {
+    ...
+};

--- a/crates/wac-parser/tests/encoding/merged-functions.wat.result
+++ b/crates/wac-parser/tests/encoding/merged-functions.wat.result
@@ -1,0 +1,52 @@
+(component
+  (type (;0;)
+    (instance
+      (type (;0;) (record (field "x" u32)))
+      (export (;1;) "x" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "y" (func (type 2)))
+      (type (;3;) (func (param "x" 1)))
+      (export (;1;) "z" (func (type 3)))
+    )
+  )
+  (import "foo:bar/baz" (instance (;0;) (type 0)))
+  (type (;1;)
+    (component
+      (type (;0;)
+        (instance
+          (type (;0;) (record (field "x" u32)))
+          (export (;1;) "x" (type (eq 0)))
+          (type (;2;) (func (param "x" 1)))
+          (export (;0;) "y" (func (type 2)))
+        )
+      )
+      (import "foo:bar/baz" (instance (;0;) (type 0)))
+    )
+  )
+  (import "unlocked-dep=<foo:bar>" (component (;0;) (type 1)))
+  (instance (;1;) (instantiate 0
+      (with "foo:bar/baz" (instance 0))
+    )
+  )
+  (type (;2;)
+    (component
+      (type (;0;)
+        (instance
+          (type (;0;) (record (field "x" u32)))
+          (export (;1;) "x" (type (eq 0)))
+          (type (;2;) (func (param "x" 1)))
+          (export (;0;) "z" (func (type 2)))
+        )
+      )
+      (import "foo:bar/baz" (instance (;0;) (type 0)))
+    )
+  )
+  (import "unlocked-dep=<foo:baz>" (component (;1;) (type 2)))
+  (instance (;2;) (instantiate 1
+      (with "foo:bar/baz" (instance 0))
+    )
+  )
+  (@producers
+    (processed-by "wac-parser" "0.1.0")
+  )
+)

--- a/crates/wac-parser/tests/encoding/merged-functions/foo/bar.wat
+++ b/crates/wac-parser/tests/encoding/merged-functions/foo/bar.wat
@@ -1,0 +1,7 @@
+(component
+  (import "foo:bar/baz" (instance
+    (type (record (field "x" u32)))
+    (export "x" (type (eq 0)))
+    (export "y" (func (param "x" 1)))
+  ))
+)

--- a/crates/wac-parser/tests/encoding/merged-functions/foo/baz.wat
+++ b/crates/wac-parser/tests/encoding/merged-functions/foo/baz.wat
@@ -1,0 +1,7 @@
+(component
+  (import "foo:bar/baz" (instance
+    (type (record (field "x" u32)))
+    (export "x" (type (eq 0)))
+    (export "z" (func (param "x" 1)))
+  ))
+)


### PR DESCRIPTION
Currently, a bug exists in merging of interfaces such that if one interface exports a function that references an exported (i.e. "named") type and another interface exports a different function that references the same exported type, the merged interface would have references to function types with types that are not present in the "encoded type index" map.

This results in the encoder re-encoding the same type and using that newly encoded type index instead of the correct type index to the named type.

Ultimately this resulted in a validation error of the encoded output where the interface wasn't valid for import because of the function not using what should be a named value type.

The fix is for the merged interface to maintain a mapping between the new type and the old types so that the "encoded type index" map is updated accordingly.