### PR TITLE
Implement support for registry packages.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,30 @@ jobs:
     - name: Run all tests
       run: cargo test --all
 
+  check:
+    name: Check feature combinations
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Rust
+      run: |
+        rustup update stable --no-self-update
+        rustup default stable
+      shell: bash
+    - name: Build without default features
+      run: cargo check --no-default-features
+    - name: Build the `wat` feature
+      run: cargo check --no-default-features --features wat
+    - name: Build the `wit` feature
+      run: cargo check --no-default-features --features wit
+    - name: Build the `registry` feature
+      run: cargo check --no-default-features --features registry
+    - name: Build all features
+      run: cargo check --all-features
+
   rustfmt:
     name: Format source code
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +96,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +122,69 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "backtrace"
@@ -122,6 +211,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,9 +242,36 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -147,6 +287,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "clap"
@@ -179,7 +332,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -193,6 +346,50 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -228,16 +425,176 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -269,10 +626,173 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+
+[[package]]
+name = "futures-task"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "gimli"
@@ -281,10 +801,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -308,10 +888,134 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -320,15 +1024,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
  "serde",
 ]
+
+[[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -348,10 +1107,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leb128"
@@ -366,10 +1158,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -397,7 +1210,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -408,6 +1221,12 @@ checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
  "logos-codegen",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -427,12 +1246,24 @@ dependencies = [
 [[package]]
 name = "miette"
 version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive 5.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
 source = "git+https://github.com/zkat/miette#7ff4f874d693a665af4df40f4e94505013e3e262"
 dependencies = [
  "backtrace",
  "backtrace-ext",
  "is-terminal",
- "miette-derive",
+ "miette-derive 5.10.0 (git+https://github.com/zkat/miette)",
  "once_cell",
  "owo-colors",
  "serde",
@@ -448,11 +1279,38 @@ dependencies = [
 [[package]]
 name = "miette-derive"
 version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
 source = "git+https://github.com/zkat/miette#7ff4f874d693a665af4df40f4e94505013e3e262"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -465,6 +1323,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +1394,12 @@ dependencies = [
  "hermit-abi 0.3.3",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -490,6 +1417,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl"
+version = "0.10.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,10 +1482,167 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pbjson"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
+dependencies = [
+ "heck",
+ "itertools 0.10.5",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a88c8d87f99a4ac14325e7a4c24af190fca261956e3b82dd7ed67e77e6c7043"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-build",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.1.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "portable-atomic"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pretty_assertions"
@@ -525,6 +1665,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,12 +1693,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b823de344848e011658ac981009100818b322421676740546f8b52ed5249428"
+dependencies = [
+ "logos",
+ "miette 5.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a5aacd1f6147ceac5e3896e0c766187dc6a9645f3b93ec821fabbaf821b887"
+dependencies = [
+ "bytes",
+ "miette 5.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fc6d0af2dec2c39da31eb02cc78cbc05b843b04f30ad78ccc6e8a342ec5518"
+dependencies = [
+ "logos",
+ "miette 5.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types",
+ "thiserror",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -560,6 +1850,35 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -598,6 +1917,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,12 +1987,18 @@ version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -623,10 +2007,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -654,7 +2102,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -666,6 +2114,125 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "base64 0.21.5",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -681,6 +2248,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spdx"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,10 +2277,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supports-color"
@@ -735,6 +2338,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
@@ -742,6 +2356,56 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -791,8 +2455,62 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -801,9 +2519,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
+ "bytes",
+ "libc",
+ "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.5.5",
  "tokio-macros",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -814,8 +2539,204 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -830,6 +2751,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,10 +2772,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wac"
@@ -853,16 +2812,20 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "indexmap 2.1.0",
+ "indicatif",
  "log",
- "miette",
+ "miette 5.10.0 (git+https://github.com/zkat/miette)",
  "owo-colors",
  "pretty_env_logger",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "wac-parser",
- "wasmparser",
+ "wac-resolver",
+ "wasmparser 0.118.1",
  "wasmprinter",
  "wat",
 ]
@@ -873,10 +2836,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.1.0",
  "log",
  "logos",
- "miette",
+ "miette 5.10.0 (git+https://github.com/zkat/miette)",
  "owo-colors",
  "pretty_assertions",
  "pretty_env_logger",
@@ -885,14 +2848,278 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
+ "wac-resolver",
  "wasm-encoder",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.118.1",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wac-resolver"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "indexmap 2.1.0",
+ "log",
+ "miette 5.10.0 (git+https://github.com/zkat/miette)",
+ "pretty_assertions",
+ "semver",
+ "tempdir",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "wac-parser",
+ "warg-client",
+ "warg-crypto",
+ "warg-protocol",
+ "warg-server",
  "wasmprinter",
  "wat",
  "wit-component",
  "wit-parser",
 ]
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "warg-api"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "itertools 0.11.0",
+ "serde",
+ "serde_with",
+ "thiserror",
+ "warg-crypto",
+ "warg-protocol",
+]
+
+[[package]]
+name = "warg-client"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "clap",
+ "dirs",
+ "futures-util",
+ "itertools 0.11.0",
+ "libc",
+ "normpath",
+ "once_cell",
+ "pathdiff",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "walkdir",
+ "warg-api",
+ "warg-crypto",
+ "warg-protocol",
+ "warg-transparency",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "warg-crypto"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "anyhow",
+ "base64 0.21.5",
+ "digest",
+ "hex",
+ "leb128",
+ "once_cell",
+ "p256",
+ "rand_core 0.6.4",
+ "secrecy",
+ "serde",
+ "sha2",
+ "signature",
+ "thiserror",
+]
+
+[[package]]
+name = "warg-protobuf"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "anyhow",
+ "pbjson",
+ "pbjson-build",
+ "pbjson-types",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "protox",
+ "regex",
+ "serde",
+ "warg-crypto",
+]
+
+[[package]]
+name = "warg-protocol"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "anyhow",
+ "base64 0.21.5",
+ "hex",
+ "indexmap 2.1.0",
+ "pbjson-types",
+ "prost",
+ "prost-types",
+ "semver",
+ "serde",
+ "serde_with",
+ "thiserror",
+ "warg-crypto",
+ "warg-protobuf",
+ "warg-transparency",
+ "wasmparser 0.108.0",
+]
+
+[[package]]
+name = "warg-server"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "clap",
+ "futures",
+ "indexmap 2.1.0",
+ "secrecy",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "warg-api",
+ "warg-crypto",
+ "warg-protocol",
+ "warg-transparency",
+ "wasmparser 0.108.0",
+]
+
+[[package]]
+name = "warg-transparency"
+version = "0.3.0-dev"
+source = "git+https://github.com/bytecodealliance/registry#351df67381051918b79f6ae8d72e18bc9bde2684"
+dependencies = [
+ "anyhow",
+ "prost",
+ "thiserror",
+ "warg-crypto",
+ "warg-protobuf",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-encoder"
@@ -910,13 +3137,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d835d67708f6374937c550ad8dd1d17c616ae009e3f00d7a0ac9f7825e78c36a"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.1.0",
  "serde",
  "serde_derive",
  "serde_json",
  "spdx",
  "wasm-encoder",
- "wasmparser",
+ "wasmparser 0.118.1",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.108.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5"
+dependencies = [
+ "indexmap 2.1.0",
+ "semver",
 ]
 
 [[package]]
@@ -925,7 +3175,7 @@ version = "0.118.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
 dependencies = [
- "indexmap",
+ "indexmap 2.1.0",
  "semver",
 ]
 
@@ -936,7 +3186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d027eb8294904fc715ac0870cebe6b0271e96b90605ee21511e7565c4ce568c"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.118.1",
 ]
 
 [[package]]
@@ -958,6 +3208,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb338ee8dee4d4cd05e6426683f21c5087dc7cfc8903e839ccf48d43332da3c"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -992,6 +3264,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +3297,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1041,6 +3346,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -1050,6 +3361,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1065,6 +3382,12 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -1074,6 +3397,12 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1089,6 +3418,12 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -1098,6 +3433,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1113,6 +3454,12 @@ checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -1124,21 +3471,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
+name = "winnow"
+version = "0.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0383266b19108dfc6314a56047aa545a1b4d1be60e799b4dbdd407b56402704b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-component"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2e0cdd27c1500cb2524810e8f40b50012355a476c1bea5d12d73620125cc04"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.4.1",
+ "indexmap 2.1.0",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
  "wasm-encoder",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.118.1",
  "wit-parser",
 ]
 
@@ -1150,7 +3516,7 @@ checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.1.0",
  "log",
  "semver",
  "serde",
@@ -1164,3 +3530,9 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["webassembly", "wasm", "components", "component-model"]
 repository = "https://github.com/bytecodealliance/wac"
 
 [dependencies]
+wac-resolver = { workspace = true, default-features = false }
 wac-parser = { workspace = true, default-features = false}
 anyhow = { workspace = true }
 clap = { workspace = true }
@@ -32,15 +33,21 @@ wat = { workspace = true }
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
 thiserror = { workspace = true }
+indexmap = { workspace = true }
 # TODO: use the next release which has support for primary labels
 miette = { git = "https://github.com/zkat/miette", features = ["fancy"] }
+semver = { workspace = true }
+indicatif = { workspace = true, optional = true}
 
 [features]
 default = []
-wat = ["wac-parser/wat"]
+wat = ["wac-resolver/wat"]
+wit = ["wac-resolver/wit"]
+registry = ["wac-resolver/registry", "indicatif"]
 
 [workspace.dependencies]
 wac-parser = { path = "crates/wac-parser", default-features = false }
+wac-resolver = { path = "crates/wac-resolver", default-features = false }
 wit-parser = "0.13.0"
 wasmparser = "0.118.1"
 wit-component = "0.19.0"
@@ -61,3 +68,11 @@ serde_json = "1.0.108"
 wat = "1.0.82"
 logos = "0.13.0"
 thiserror = "1.0.50"
+# TODO: update these to 0.3.0 when it's released
+warg-client = { git = "https://github.com/bytecodealliance/registry" }
+warg-protocol = { git = "https://github.com/bytecodealliance/registry" }
+warg-crypto = { git = "https://github.com/bytecodealliance/registry" }
+warg-server = { git = "https://github.com/bytecodealliance/registry" }
+futures = "0.3.29"
+indicatif = "0.17.7"
+pretty_assertions = "1.4.0"

--- a/crates/wac-parser/Cargo.toml
+++ b/crates/wac-parser/Cargo.toml
@@ -19,26 +19,25 @@ indexmap = { workspace = true }
 id-arena = { workspace = true }
 serde = { workspace = true }
 wasmparser = { workspace = true }
-wit-parser = { workspace = true }
-wit-component = { workspace = true }
 wasm-encoder = { workspace = true }
 wasm-metadata = { workspace = true }
-wat = { workspace = true, optional = true }
 # TODO: use the next release which has support for primary labels
 miette = { git = "https://github.com/zkat/miette", features = ["serde"] }
 
-[features]
-default = ["wat"]
-
 [dev-dependencies]
+wac-resolver = { workspace = true, default-features = false, features = ["wat", "wit"] }
 owo-colors = "3.5.0"
-pretty_assertions = "1.4.0"
+pretty_assertions = { workspace = true }
 pretty_env_logger = { workspace = true }
 rayon = "1.8.0"
+tokio = { workspace = true }
 serde_json = { workspace = true }
 wasmprinter = { workspace = true }
 # TODO: use the next release which has support for primary labels
-miette = { git = "https://github.com/zkat/miette", features = ["serde", "fancy"] }
+miette = { git = "https://github.com/zkat/miette", features = [
+    "serde",
+    "fancy",
+] }
 
 [[test]]
 name = "parser"

--- a/crates/wac-parser/src/resolution/encoding.rs
+++ b/crates/wac-parser/src/resolution/encoding.rs
@@ -22,7 +22,7 @@ fn package_import_name(package: &Package) -> String {
     let mut name = String::new();
     write!(&mut name, "unlocked-dep=<{name}", name = package.name).unwrap();
     if let Some(version) = &package.version {
-        write!(&mut name, "@>={version}", version = version).unwrap();
+        write!(&mut name, "@{{>={version}}}", version = version).unwrap();
     }
     write!(&mut name, ">").unwrap();
     name

--- a/crates/wac-resolver/Cargo.toml
+++ b/crates/wac-resolver/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "wac-resolver"
+description = "A library for package resolvers for WAC document resolution."
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+wac-parser = { workspace = true }
+semver = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+wit-component = { workspace = true }
+indexmap = { workspace = true }
+wat = { workspace = true, optional = true }
+wit-parser = { workspace = true, optional = true }
+# TODO: use the next release which has support for primary labels
+miette = { git = "https://github.com/zkat/miette", features = ["fancy"] }
+warg-client = { workspace = true, optional = true }
+warg-protocol = { workspace = true, optional = true }
+warg-crypto = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+
+[dev-dependencies]
+wasmprinter = { workspace = true }
+warg-server = { workspace = true }
+pretty_assertions = { workspace = true }
+tokio-util = "0.7.10"
+tempdir = "0.3.7"
+
+[features]
+default = ["registry"]
+wat = ["dep:wat"]
+wit = ["wit-parser"]
+registry = ["warg-client", "warg-protocol", "warg-crypto", "tokio", "futures"]

--- a/crates/wac-resolver/src/fs.rs
+++ b/crates/wac-resolver/src/fs.rs
@@ -1,0 +1,169 @@
+use super::Error;
+use anyhow::{anyhow, Context, Result};
+use indexmap::IndexMap;
+use miette::SourceSpan;
+use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
+use wac_parser::PackageKey;
+
+/// Used to resolve packages from the file system.
+pub struct FileSystemPackageResolver {
+    root: PathBuf,
+    overrides: HashMap<String, PathBuf>,
+    error_on_unknown: bool,
+}
+
+impl FileSystemPackageResolver {
+    /// Creates a new file system resolver with the given root directory.
+    pub fn new(
+        root: impl Into<PathBuf>,
+        overrides: HashMap<String, PathBuf>,
+        error_on_unknown: bool,
+    ) -> Self {
+        Self {
+            root: root.into(),
+            overrides,
+            error_on_unknown,
+        }
+    }
+
+    /// Resolves the provided package keys to packages.
+    pub fn resolve<'a>(
+        &self,
+        keys: &IndexMap<PackageKey<'a>, SourceSpan>,
+    ) -> Result<IndexMap<PackageKey<'a>, Arc<Vec<u8>>>, Error> {
+        let mut packages = IndexMap::new();
+        for (key, span) in keys.iter() {
+            let path = match self.overrides.get(key.name) {
+                Some(path) if key.version.is_none() => {
+                    if !path.is_file() {
+                        return Err(Error::PackageResolutionFailure {
+                            name: key.name.to_string(),
+                            span: *span,
+                            source: anyhow!(
+                                "local path `{path}` for package `{name}` does not exist",
+                                path = path.display(),
+                                name = key.name
+                            ),
+                        });
+                    }
+
+                    path.clone()
+                }
+                _ => {
+                    let mut path = self.root.clone();
+                    for segment in key.name.split(':') {
+                        path.push(segment);
+                    }
+
+                    if let Some(version) = key.version {
+                        path.push(version.to_string());
+                    }
+
+                    // If the path is not a directory, use a `.wasm` or `.wat` extension
+                    if !path.is_dir() {
+                        path.set_extension("wasm");
+
+                        #[cfg(feature = "wat")]
+                        {
+                            path.set_extension("wat");
+                            if !path.exists() {
+                                path.set_extension("wasm");
+                            }
+                        }
+                    }
+
+                    path
+                }
+            };
+
+            // First check to see if a directory exists.
+            // If so, then treat it as a textual WIT package.
+            #[cfg(feature = "wit")]
+            if path.is_dir() {
+                log::debug!(
+                    "loading WIT package from directory `{path}`",
+                    path = path.display()
+                );
+
+                let mut resolve = wit_parser::Resolve::new();
+                let (pkg, _) =
+                    resolve
+                        .push_dir(&path)
+                        .map_err(|e| Error::PackageResolutionFailure {
+                            name: key.name.to_string(),
+                            span: *span,
+                            source: e,
+                        })?;
+
+                packages.insert(
+                    *key,
+                    Arc::new(
+                        wit_component::encode(Some(true), &resolve, pkg)
+                            .with_context(|| {
+                                format!(
+                                    "failed to encode WIT package from directory `{path}`",
+                                    path = path.display()
+                                )
+                            })
+                            .map_err(|e| Error::PackageResolutionFailure {
+                                name: key.name.to_string(),
+                                span: *span,
+                                source: e,
+                            })?,
+                    ),
+                );
+
+                continue;
+            }
+
+            if !path.is_file() {
+                log::debug!("package `{path}` does not exist", path = path.display());
+                if self.error_on_unknown {
+                    return Err(Error::UnknownPackage {
+                        name: key.name.to_string(),
+                        span: *span,
+                    });
+                }
+                continue;
+            }
+
+            log::debug!("loading package from `{path}`", path = path.display());
+            let bytes = fs::read(&path)
+                .with_context(|| format!("failed to read package `{path}`", path = path.display()))
+                .map_err(|e| Error::PackageResolutionFailure {
+                    name: key.name.to_string(),
+                    span: *span,
+                    source: e,
+                })?;
+
+            #[cfg(feature = "wat")]
+            if path.extension().and_then(std::ffi::OsStr::to_str) == Some("wat") {
+                let bytes = match wat::parse_bytes(&bytes) {
+                    Ok(std::borrow::Cow::Borrowed(_)) => bytes,
+                    Ok(std::borrow::Cow::Owned(wat)) => wat,
+                    Err(mut e) => {
+                        e.set_path(path);
+                        return Err(Error::PackageResolutionFailure {
+                            name: key.name.to_string(),
+                            span: *span,
+                            source: anyhow!(e),
+                        });
+                    }
+                };
+
+                packages.insert(*key, Arc::new(bytes));
+                continue;
+            }
+
+            packages.insert(*key, Arc::new(bytes));
+        }
+
+        Ok(packages)
+    }
+}
+
+impl Default for FileSystemPackageResolver {
+    fn default() -> Self {
+        Self::new("deps", Default::default(), true)
+    }
+}

--- a/crates/wac-resolver/src/lib.rs
+++ b/crates/wac-resolver/src/lib.rs
@@ -1,0 +1,140 @@
+//! Modules for package resolvers.
+
+use indexmap::IndexMap;
+use miette::{Diagnostic, SourceSpan};
+use wac_parser::{ast::Document, PackageKey};
+
+mod fs;
+#[cfg(feature = "registry")]
+mod registry;
+mod visitor;
+
+pub use fs::*;
+#[cfg(feature = "registry")]
+pub use registry::*;
+pub use visitor::*;
+
+/// Represents a package resolution error.
+#[derive(thiserror::Error, Diagnostic, Debug)]
+#[diagnostic(code("failed to resolve document"))]
+pub enum Error {
+    /// An unknown package was encountered.
+    #[error("unknown package `{name}`")]
+    UnknownPackage {
+        /// The name of the package.
+        name: String,
+        /// The span where the error occurred.
+        #[label(primary, "unknown package `{name}`")]
+        span: SourceSpan,
+    },
+    /// An unknown package version was encountered.
+    #[cfg(feature = "registry")]
+    #[error("version {version} of package `{name}` does not exist")]
+    UnknownPackageVersion {
+        /// The name of the package.
+        name: String,
+        /// The version of the package that does not exist.
+        version: semver::Version,
+        /// The span where the error occurred.
+        #[label(primary, "unknown package version `{version}`")]
+        span: SourceSpan,
+    },
+    /// Cannot instantiate the package being defined.
+    #[error("cannot instantiate the package being defined")]
+    CannotInstantiateSelf {
+        /// The span where the error occurred.
+        #[label(primary, "cannot instantiate self")]
+        span: SourceSpan,
+    },
+    /// Cannot instantiate the package being defined.
+    #[error("package `{name}` does not exist in the registry")]
+    PackageDoesNotExist {
+        /// The name of the package that does not exist.
+        name: String,
+        /// The span where the error occurred.
+        #[label(primary, "package `{name}` does not exist")]
+        span: SourceSpan,
+    },
+    /// The requested package version has been yanked.
+    #[cfg(feature = "registry")]
+    #[error("version {version} of package `{name}` has been yanked")]
+    PackageVersionYanked {
+        /// The name of the package.
+        name: String,
+        /// The version of the package that has been yanked.
+        version: semver::Version,
+        /// The span where the error occurred.
+        #[label(primary, "{version} has been yanked")]
+        span: SourceSpan,
+    },
+    /// A package log was empty.
+    #[cfg(feature = "registry")]
+    #[error("a release for package `{name}` has not yet been published")]
+    PackageLogEmpty {
+        /// The name of the package.
+        name: String,
+        /// The span where the error occurred.
+        #[label(primary, "package `{name}` has no releases")]
+        span: SourceSpan,
+    },
+    /// A failure occurred while updating logs from the registry.
+    #[cfg(feature = "registry")]
+    #[error("failed to update registry logs")]
+    RegistryUpdateFailure {
+        /// The underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+    /// A failure occurred while downloading content from the registry.
+    #[cfg(feature = "registry")]
+    #[error("failed to download content from the registry")]
+    RegistryDownloadFailure {
+        /// The underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+    /// A failure occurred while reading content from registry storage.
+    #[cfg(feature = "registry")]
+    #[error("failed to read content path `{path}`", path = .path.display())]
+    RegistryContentFailure {
+        /// The path to the content.
+        path: std::path::PathBuf,
+        /// The underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+    /// A package failed to resolve.
+    #[error("failed to resolve package `{name}`")]
+    PackageResolutionFailure {
+        /// The name of the package.
+        name: String,
+        /// The span where the error occurred.
+        #[label(primary, "package `{name}` failed to resolve")]
+        span: SourceSpan,
+        /// The underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+/// Builds a map of packages referenced in a document to the first span
+/// which references the package.
+pub fn packages<'a>(
+    document: &'a Document<'a>,
+) -> Result<IndexMap<PackageKey<'a>, SourceSpan>, Error> {
+    let mut keys = IndexMap::new();
+    let mut visitor = PackageVisitor::new(|name, version, span| {
+        if keys.insert(PackageKey { name, version }, span).is_none() {
+            if let Some(version) = version {
+                log::debug!("discovered reference to package `{name}` ({version})");
+            } else {
+                log::debug!("discovered reference to package `{name}`");
+            }
+        }
+
+        true
+    });
+
+    visitor.visit(document)?;
+    Ok(keys)
+}

--- a/crates/wac-resolver/src/registry.rs
+++ b/crates/wac-resolver/src/registry.rs
@@ -1,0 +1,317 @@
+use super::Error;
+use anyhow::Result;
+use futures::{stream::FuturesUnordered, StreamExt};
+use indexmap::{IndexMap, IndexSet};
+use miette::SourceSpan;
+use semver::{Comparator, Op, Version, VersionReq};
+use std::{fs, path::Path, sync::Arc};
+use wac_parser::PackageKey;
+use warg_client::{
+    storage::{ContentStorage, RegistryStorage},
+    Client, ClientError, Config, FileSystemClient,
+};
+use warg_crypto::hash::AnyHash;
+
+/// Implemented by progress bars.
+///
+/// This is used to abstract a UI for the registry resolver.
+pub trait ProgressBar {
+    /// Initializes the progress bar with the given count.
+    fn init(&self, count: usize);
+
+    /// Prints a message and then redraws the progress bar.
+    fn println(&self, status: &str, msg: &str);
+
+    /// Increments the progress bar by the given amount.
+    fn inc(&self, delta: usize);
+
+    // Finishes the progress bar.
+    fn finish(&self);
+}
+
+/// Used to resolve packages from a Warg registry.
+///
+/// Note that the registry will be locked for the lifetime of
+/// the resolver.
+pub struct RegistryPackageResolver {
+    client: Arc<FileSystemClient>,
+    bar: Option<Box<dyn ProgressBar>>,
+}
+
+impl RegistryPackageResolver {
+    /// Creates a new registry package resolver using the default
+    /// client configuration file.
+    ///
+    /// If `url` is `None`, the default URL will be used.
+    pub fn new(url: Option<&str>, bar: Option<Box<dyn ProgressBar>>) -> Result<Self> {
+        let config = Config::from_default_file()?.unwrap_or_default();
+        Ok(Self {
+            client: Arc::new(Client::new_with_config(url, &config)?),
+            bar,
+        })
+    }
+
+    /// Creates a new registry package resolver with the given configuration.
+    ///
+    /// If `url` is `None`, the default URL will be used.
+    pub fn new_with_config(
+        url: Option<&str>,
+        config: &Config,
+        bar: Option<Box<dyn ProgressBar>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            client: Arc::new(Client::new_with_config(url, config)?),
+            bar,
+        })
+    }
+
+    /// Resolves the provided package keys to packages.
+    ///
+    /// If the package isn't found, an error is returned.
+    pub async fn resolve<'a>(
+        &self,
+        keys: &IndexMap<PackageKey<'a>, SourceSpan>,
+    ) -> Result<IndexMap<PackageKey<'a>, Arc<Vec<u8>>>, Error> {
+        // Start by fetching any required package logs
+        self.fetch(keys).await?;
+
+        // All the logs have been updated, now we need to see what content
+        // is missing from local storage.
+        let mut packages = IndexMap::new();
+        let missing = self.find_missing_content(keys, &mut packages).await?;
+
+        if !missing.is_empty() {
+            if let Some(bar) = self.bar.as_ref() {
+                bar.init(missing.len());
+                bar.println("Downloading", "package content from the registry");
+            }
+
+            let mut tasks = FuturesUnordered::new();
+            for (index, hash) in missing.keys().enumerate() {
+                let client = self.client.clone();
+                let hash = hash.clone();
+                tasks.push(tokio::spawn(async move {
+                    Ok((index, client.download_content(&hash).await?))
+                }));
+            }
+
+            let count = tasks.len();
+            let mut finished = 0;
+            while let Some(res) = tasks.next().await {
+                let (index, path) = res
+                    .unwrap()
+                    .map_err(|e| Error::RegistryDownloadFailure { source: e })?;
+
+                let (hash, (version, set)) = missing.get_index(index).unwrap();
+                log::debug!("downloaded content `{hash}`");
+
+                finished += 1;
+
+                if let Some(bar) = self.bar.as_ref() {
+                    bar.inc(1);
+                    let first = set.first().unwrap();
+                    bar.println(
+                        "Downloaded",
+                        &format!("package `{name}` {version} ({hash})", name = first.name),
+                    )
+                }
+
+                let contents = Self::read_contents(&path)?;
+                for key in set {
+                    packages.insert(*key, contents.clone());
+                }
+            }
+
+            assert_eq!(finished, count);
+
+            if let Some(bar) = self.bar.as_ref() {
+                bar.finish();
+            }
+        }
+
+        Ok(packages)
+    }
+
+    async fn fetch(&self, keys: &IndexMap<PackageKey<'_>, SourceSpan>) -> Result<(), Error> {
+        // First check if we already have the packages in client storage.
+        // If not, we'll fetch the logs from the registry.
+        let mut fetch = IndexMap::new();
+        for (key, span) in keys {
+            let id =
+                key.name
+                    .parse()
+                    .map_err(|e: anyhow::Error| Error::PackageResolutionFailure {
+                        name: key.name.to_string(),
+                        span: *span,
+                        source: e,
+                    })?;
+
+            // Load the package from client storage to see if we already
+            // have a matching version present.
+            if let Some(info) = self
+                .client
+                .registry()
+                .load_package(&id)
+                .await
+                .map_err(|e| Error::PackageResolutionFailure {
+                    name: key.name.to_string(),
+                    span: *span,
+                    source: e,
+                })?
+            {
+                if let Some(version) = key.version {
+                    let req = VersionReq {
+                        comparators: vec![Comparator {
+                            op: Op::Exact,
+                            major: version.major,
+                            minor: Some(version.minor),
+                            patch: Some(version.patch),
+                            pre: version.pre.clone(),
+                        }],
+                    };
+
+                    // Version already present, no need to fetch the log
+                    if info.state.find_latest_release(&req).is_some() {
+                        log::debug!(
+                            "package log for `{name}` has a release version {version}",
+                            name = key.name
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            fetch.entry(id).or_insert_with(|| {
+                log::debug!(
+                    "fetching log for package `{name}` from the registry",
+                    name = key.name
+                );
+                span
+            });
+        }
+
+        // Fetch the logs
+        if !fetch.is_empty() {
+            if let Some(bar) = self.bar.as_ref() {
+                bar.init(1);
+                bar.println("Updating", "package logs from the registry");
+            }
+
+            match self.client.upsert(fetch.keys()).await {
+                Ok(_) => {
+                    if let Some(bar) = self.bar.as_ref() {
+                        bar.inc(1);
+                        bar.finish();
+                    }
+                }
+                Err(ClientError::PackageDoesNotExist { name }) => {
+                    return Err(Error::PackageDoesNotExist {
+                        name: name.to_string(),
+                        span: *fetch[&name],
+                    })
+                }
+                Err(e) => {
+                    return Err(Error::RegistryUpdateFailure { source: e.into() });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn find_missing_content<'a>(
+        &self,
+        keys: &IndexMap<PackageKey<'a>, SourceSpan>,
+        packages: &mut IndexMap<PackageKey<'a>, Arc<Vec<u8>>>,
+    ) -> Result<IndexMap<AnyHash, (Version, IndexSet<PackageKey<'a>>)>, Error> {
+        let mut downloads: IndexMap<AnyHash, (Version, IndexSet<PackageKey<'a>>)> = IndexMap::new();
+        for (key, span) in keys {
+            let id =
+                key.name
+                    .parse()
+                    .map_err(|e: anyhow::Error| Error::PackageResolutionFailure {
+                        name: key.name.to_string(),
+                        span: *span,
+                        source: e,
+                    })?;
+
+            let info = self
+                .client
+                .registry()
+                .load_package(&id)
+                .await
+                .map_err(|e| Error::PackageResolutionFailure {
+                    name: key.name.to_string(),
+                    span: *span,
+                    source: e,
+                })?
+                .expect("package log should be present after fetching");
+
+            let req = match key.version {
+                Some(v) => VersionReq {
+                    comparators: vec![Comparator {
+                        op: Op::Exact,
+                        major: v.major,
+                        minor: Some(v.minor),
+                        patch: Some(v.patch),
+                        pre: v.pre.clone(),
+                    }],
+                },
+                None => VersionReq::STAR,
+            };
+
+            let release = match info.state.find_latest_release(&req) {
+                Some(release) if !release.yanked() => release,
+                Some(release) => {
+                    return Err(Error::PackageVersionYanked {
+                        name: key.name.to_string(),
+                        version: release.version.clone(),
+                        span: *span,
+                    });
+                }
+                None => {
+                    if let Some(version) = key.version {
+                        return Err(Error::UnknownPackageVersion {
+                            name: key.name.to_string(),
+                            version: version.clone(),
+                            span: *span,
+                        });
+                    } else {
+                        return Err(Error::PackageLogEmpty {
+                            name: key.name.to_string(),
+                            span: *span,
+                        });
+                    }
+                }
+            };
+
+            let hash = release.content().unwrap();
+            if let Some(path) = self.client.content().content_location(hash) {
+                packages.insert(*key, Self::read_contents(&path)?);
+            } else {
+                log::debug!(
+                    "downloading content for version {version} of package `{name}`",
+                    name = key.name,
+                    version = release.version
+                );
+
+                downloads
+                    .entry(hash.clone())
+                    .or_insert_with(|| (release.version.clone(), Default::default()))
+                    .1
+                    .insert(*key);
+            }
+        }
+
+        Ok(downloads)
+    }
+
+    fn read_contents(path: &Path) -> Result<Arc<Vec<u8>>, Error> {
+        Ok(Arc::new(fs::read(path).map_err(|e| {
+            Error::RegistryContentFailure {
+                path: path.to_path_buf(),
+                source: e.into(),
+            }
+        })?))
+    }
+}

--- a/crates/wac-resolver/src/visitor.rs
+++ b/crates/wac-resolver/src/visitor.rs
@@ -1,0 +1,178 @@
+use miette::SourceSpan;
+use semver::Version;
+use wac_parser::ast::{
+    Document, Expr, ExternType, ImportStatement, ImportType, InstantiationArgument, InterfaceItem,
+    PrimaryExpr, Statement, TypeStatement, UsePath, WorldItem, WorldItemPath, WorldRef,
+};
+
+use crate::Error;
+
+/// A visitor of packages referenced in a document.
+///
+/// This can be used to collect all of the packages referenced
+/// in a document so that they may all be resolved at the same time.
+pub struct PackageVisitor<T>(T);
+
+impl<'a, T> PackageVisitor<T>
+where
+    T: FnMut(&'a str, Option<&'a Version>, SourceSpan) -> bool,
+{
+    /// Creates a new package visitor with the given callback.
+    ///
+    /// The callback receives the package name, optional version, and
+    /// the span of the package name.
+    pub fn new(cb: T) -> Self {
+        Self(cb)
+    }
+
+    /// Visits any package names referenced in the document.
+    ///
+    /// The package names are visited in-order and will not deduplicate
+    /// names/versions that are referenced multiple times.
+    pub fn visit(&mut self, doc: &'a Document) -> Result<(), Error> {
+        for stmt in &doc.statements {
+            match stmt {
+                Statement::Import(i) => {
+                    if !self.import_statement(i) {
+                        break;
+                    }
+                }
+                Statement::Type(t) => {
+                    if !self.type_statement(t) {
+                        break;
+                    }
+                }
+                Statement::Let(l) => {
+                    if !self.expr(doc.package.name, &l.expr)? {
+                        break;
+                    }
+                }
+                Statement::Export(e) => {
+                    if !self.expr(doc.package.name, &e.expr)? {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn import_statement(&mut self, stmt: &'a ImportStatement) -> bool {
+        match &stmt.ty {
+            ImportType::Package(p) => (self.0)(p.name, p.version.as_ref(), p.package_name_span()),
+            ImportType::Interface(i) => {
+                for item in &i.items {
+                    if !self.interface_item(item) {
+                        return false;
+                    }
+                }
+
+                true
+            }
+            ImportType::Func(_) | ImportType::Ident(_) => true,
+        }
+    }
+
+    fn type_statement(&mut self, stmt: &'a TypeStatement) -> bool {
+        match stmt {
+            TypeStatement::Interface(i) => {
+                for item in &i.items {
+                    if !self.interface_item(item) {
+                        return false;
+                    }
+                }
+
+                true
+            }
+            TypeStatement::World(w) => {
+                for item in &w.items {
+                    if !self.world_item(item) {
+                        return false;
+                    }
+                }
+
+                true
+            }
+            TypeStatement::Type(_) => true,
+        }
+    }
+
+    fn interface_item(&mut self, item: &'a InterfaceItem) -> bool {
+        match item {
+            InterfaceItem::Use(u) => match &u.path {
+                UsePath::Package(p) => (self.0)(p.name, p.version.as_ref(), p.package_name_span()),
+                UsePath::Ident(_) => true,
+            },
+            InterfaceItem::Type(_) | InterfaceItem::Export(_) => true,
+        }
+    }
+
+    fn world_item(&mut self, item: &'a WorldItem) -> bool {
+        match item {
+            WorldItem::Use(u) => match &u.path {
+                UsePath::Package(p) => (self.0)(p.name, p.version.as_ref(), p.package_name_span()),
+                UsePath::Ident(_) => true,
+            },
+            WorldItem::Type(_) => true,
+            WorldItem::Import(i) => self.world_item_path(&i.path),
+            WorldItem::Export(e) => self.world_item_path(&e.path),
+            WorldItem::Include(i) => match &i.world {
+                WorldRef::Package(p) => (self.0)(p.name, p.version.as_ref(), p.package_name_span()),
+                WorldRef::Ident(_) => true,
+            },
+        }
+    }
+
+    fn world_item_path(&mut self, path: &'a WorldItemPath) -> bool {
+        match path {
+            WorldItemPath::Named(n) => match &n.ty {
+                ExternType::Interface(i) => {
+                    for item in &i.items {
+                        if !self.interface_item(item) {
+                            return false;
+                        }
+                    }
+
+                    true
+                }
+                ExternType::Ident(_) | ExternType::Func(_) => true,
+            },
+            WorldItemPath::Package(p) => {
+                (self.0)(p.name, p.version.as_ref(), p.package_name_span())
+            }
+            WorldItemPath::Ident(_) => true,
+        }
+    }
+
+    fn expr(&mut self, this: &str, expr: &'a Expr) -> Result<bool, Error> {
+        match &expr.primary {
+            PrimaryExpr::New(e) => {
+                if e.package.name == this {
+                    return Err(Error::CannotInstantiateSelf {
+                        span: e.package.span,
+                    });
+                }
+
+                if !(self.0)(e.package.name, e.package.version.as_ref(), e.package.span) {
+                    return Ok(false);
+                }
+
+                for arg in &e.arguments {
+                    match arg {
+                        InstantiationArgument::Named(a) => {
+                            if !self.expr(this, &a.expr)? {
+                                return Ok(false);
+                            }
+                        }
+                        InstantiationArgument::Ident(_) => continue,
+                    }
+                }
+
+                Ok(true)
+            }
+            PrimaryExpr::Nested(e) => self.expr(this, &e.0),
+            PrimaryExpr::Ident(_) => Ok(true),
+        }
+    }
+}

--- a/crates/wac-resolver/tests/registry.rs
+++ b/crates/wac-resolver/tests/registry.rs
@@ -1,0 +1,118 @@
+use crate::support::{publish_component, publish_wit, spawn_server};
+use anyhow::Result;
+use pretty_assertions::assert_eq;
+use tempdir::TempDir;
+use wac_parser::{ast::Document, Composition, EncodingOptions};
+use wac_resolver::{packages, RegistryPackageResolver};
+
+mod support;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_resolves_registry_packages() -> Result<()> {
+    let root = TempDir::new("test")?;
+    let (_server, config) = spawn_server(root.path()).await?;
+    config.write_to_file(&root.path().join("warg-config.json"))?;
+
+    publish_component(
+        &config,
+        "test:comp",
+        "0.1.0",
+        r#"
+(component
+  (import "test:wit/foo" (instance (export "bar" (func))))
+  (export "test:wit/foo" (instance 0))
+)
+"#,
+        true,
+    )
+    .await?;
+
+    publish_wit(
+        &config,
+        "test:wit",
+        "0.1.0",
+        r#"
+package test:wit;
+
+interface foo {
+    bar: func();
+}
+"#,
+        true,
+    )
+    .await?;
+
+    let document = Document::parse(
+        r#"
+package test:composition;
+
+import x: test:wit/foo;
+import y: interface {
+    bar: func();
+};
+
+let i1 = new test:comp { x };
+let i2 = new test:comp { "test:wit/foo": y };
+
+export i1.foo;
+export i2.foo as "bar";
+
+"#,
+    )?;
+
+    let resolver = RegistryPackageResolver::new_with_config(None, &config, None)?;
+    let packages = resolver.resolve(&packages(&document)?).await?;
+
+    let composition = Composition::from_ast(&document, packages)?;
+    let bytes = composition.encode(EncodingOptions::default())?;
+
+    assert_eq!(
+        wasmprinter::print_bytes(bytes)?,
+        r#"(component
+  (type (;0;)
+    (instance
+      (type (;0;) (func))
+      (export (;0;) "bar" (func (type 0)))
+    )
+  )
+  (import "test:wit/foo" (instance (;0;) (type 0)))
+  (type (;1;)
+    (instance
+      (type (;0;) (func))
+      (export (;0;) "bar" (func (type 0)))
+    )
+  )
+  (import "y" (instance (;1;) (type 1)))
+  (type (;2;)
+    (component
+      (type (;0;)
+        (instance
+          (type (;0;) (func))
+          (export (;0;) "bar" (func (type 0)))
+        )
+      )
+      (import "test:wit/foo" (instance (;0;) (type 0)))
+      (export (;1;) "test:wit/foo" (instance (type 0)))
+    )
+  )
+  (import "unlocked-dep=<test:comp>" (component (;0;) (type 2)))
+  (instance (;2;) (instantiate 0
+      (with "test:wit/foo" (instance 0))
+    )
+  )
+  (instance (;3;) (instantiate 0
+      (with "test:wit/foo" (instance 1))
+    )
+  )
+  (alias export 2 "test:wit/foo" (instance (;4;)))
+  (alias export 3 "test:wit/foo" (instance (;5;)))
+  (export (;6;) "test:wit/foo" (instance 4))
+  (export (;7;) "bar" (instance 5))
+  (@producers
+    (processed-by "wac-parser" "0.1.0")
+  )
+)"#
+    );
+
+    Ok(())
+}

--- a/crates/wac-resolver/tests/support/mod.rs
+++ b/crates/wac-resolver/tests/support/mod.rs
@@ -1,0 +1,152 @@
+use anyhow::{Context, Result};
+use std::{path::Path, time::Duration};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use warg_client::{
+    storage::{ContentStorage, PublishEntry, PublishInfo},
+    FileSystemClient,
+};
+use warg_crypto::signing::PrivateKey;
+use warg_protocol::{operator::NamespaceState, registry::PackageName};
+use warg_server::{policy::content::WasmContentPolicy, Config, Server};
+use wit_parser::{Resolve, UnresolvedPackage};
+
+pub fn test_operator_key() -> &'static str {
+    "ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk="
+}
+
+pub fn test_signing_key() -> &'static str {
+    "ecdsa-p256:2CV1EpLaSYEn4In4OAEDAj5O4Hzu8AFAxgHXuG310Ew="
+}
+
+pub async fn publish_component(
+    config: &warg_client::Config,
+    name: &str,
+    version: &str,
+    wat: &str,
+    init: bool,
+) -> Result<()> {
+    publish(
+        config,
+        &name.parse()?,
+        version,
+        wat::parse_str(wat).context("failed to parse component for publishing")?,
+        init,
+    )
+    .await
+}
+
+pub async fn publish_wit(
+    config: &warg_client::Config,
+    name: &str,
+    version: &str,
+    wit: &str,
+    init: bool,
+) -> Result<()> {
+    let mut resolve = Resolve::new();
+    let pkg = resolve
+        .push(
+            UnresolvedPackage::parse(Path::new("foo.wit"), wit)
+                .context("failed to parse wit for publishing")?,
+        )
+        .context("failed to resolve wit for publishing")?;
+
+    let bytes = wit_component::encode(Some(true), &resolve, pkg)
+        .context("failed to encode wit for publishing")?;
+
+    publish(config, &name.parse()?, version, bytes, init).await
+}
+
+pub async fn publish(
+    config: &warg_client::Config,
+    name: &PackageName,
+    version: &str,
+    content: Vec<u8>,
+    init: bool,
+) -> Result<()> {
+    let client = FileSystemClient::new_with_config(None, config)?;
+
+    let digest = client
+        .content()
+        .store_content(
+            Box::pin(futures::stream::once(async move { Ok(content.into()) })),
+            None,
+        )
+        .await
+        .context("failed to store component for publishing")?;
+
+    let mut entries = Vec::with_capacity(2);
+    if init {
+        entries.push(PublishEntry::Init);
+    }
+    entries.push(PublishEntry::Release {
+        version: version.parse().unwrap(),
+        content: digest,
+    });
+
+    let record_id = client
+        .publish_with_info(
+            &PrivateKey::decode(test_signing_key().to_string()).unwrap(),
+            PublishInfo {
+                name: name.clone(),
+                head: None,
+                entries,
+            },
+        )
+        .await
+        .context("failed to publish component")?;
+
+    client
+        .wait_for_publish(name, &record_id, Duration::from_secs(1))
+        .await?;
+
+    Ok(())
+}
+
+pub struct ServerInstance {
+    task: Option<JoinHandle<()>>,
+    shutdown: CancellationToken,
+}
+
+impl Drop for ServerInstance {
+    fn drop(&mut self) {
+        futures::executor::block_on(async move {
+            self.shutdown.cancel();
+            self.task.take().unwrap().await.ok();
+        });
+    }
+}
+
+/// Spawns a server as a background task.
+pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::Config)> {
+    let shutdown = CancellationToken::new();
+    let config = Config::new(
+        PrivateKey::decode(test_operator_key().to_string())?,
+        Some(vec![("test".to_string(), NamespaceState::Defined)]),
+        root.join("server"),
+    )
+    .with_addr(([127, 0, 0, 1], 0))
+    .with_shutdown(shutdown.clone().cancelled_owned())
+    .with_checkpoint_interval(Duration::from_millis(100))
+    .with_content_policy(WasmContentPolicy::default());
+
+    let server = Server::new(config).initialize().await?;
+    let addr = server.local_addr()?;
+
+    let task = tokio::spawn(async move {
+        server.serve().await.unwrap();
+    });
+
+    let instance = ServerInstance {
+        task: Some(task),
+        shutdown,
+    };
+
+    let config = warg_client::Config {
+        default_url: Some(format!("http://{addr}")),
+        registries_dir: Some(root.join("registries")),
+        content_dir: Some(root.join("content")),
+    };
+
+    Ok((instance, config))
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,36 @@
+use indicatif::ProgressDrawTarget;
+use owo_colors::{OwoColorize, Stream};
+
+pub struct ProgressBar(indicatif::ProgressBar);
+
+impl ProgressBar {
+    pub fn new() -> Self {
+        let pb = indicatif::ProgressBar::new(0);
+        pb.set_draw_target(ProgressDrawTarget::stderr());
+        Self(pb)
+    }
+}
+
+impl wac_resolver::ProgressBar for ProgressBar {
+    fn init(&self, count: usize) {
+        self.0.reset();
+        self.0.set_length(count as u64);
+    }
+
+    fn println(&self, status: &str, msg: &str) {
+        self.0.suspend(|| {
+            eprintln!(
+                "{status:>12} {msg}",
+                status = status.if_supports_color(Stream::Stderr, |text| text.bright_green())
+            )
+        });
+    }
+
+    fn inc(&self, delta: usize) {
+        self.0.inc(delta as u64);
+    }
+
+    fn finish(&self) {
+        self.0.finish_and_clear();
+    }
+}


### PR DESCRIPTION
This PR implements support for referencing packages from a registry.

A new `wac-resolver` crate was added and the resolvers implementation was refactored into it; package resolution now occurs before document resolution.

A `registry` feature was added to the CLI tool; when enabled, a `--registry` CLI option is accepted to point at the registry to use.

The CLI also supports Warg client configuration files (default or local).

A simple `indicatif` progress bar was added to display the number of packages that need to be downloaded from the registry.

A new integration test that uses packages from a registry was also implemented.