### PR TITLE
Improve encoding of used types.

### DIFF
--- a/crates/wac-parser/src/resolution.rs
+++ b/crates/wac-parser/src/resolution.rs
@@ -32,25 +32,6 @@ where
     s.end()
 }
 
-fn serialize_id_key_map<T, V, S>(
-    map: &IndexMap<Id<T>, V>,
-    serializer: S,
-) -> std::result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: Serialize,
-    V: Serialize,
-{
-    use serde::ser::SerializeMap;
-
-    let mut s = serializer.serialize_map(Some(map.len()))?;
-    for (k, v) in map {
-        s.serialize_entry(&k.index(), v)?;
-    }
-
-    s.end()
-}
-
 fn serialize_id_value_map<K, T, S>(
     map: &IndexMap<K, Id<T>>,
     serializer: S,

--- a/crates/wac-parser/tests/resolution/package-use-item.wac.result
+++ b/crates/wac-parser/tests/resolution/package-use-item.wac.result
@@ -77,9 +77,10 @@
       {
         "id": "foo:bar/qux",
         "uses": {
-          "1": [
-            2
-          ]
+          "z": {
+            "interface": 1,
+            "name": "c"
+          }
         },
         "exports": {
           "z": {
@@ -100,11 +101,15 @@
       {
         "id": "test:comp/i@0.0.1",
         "uses": {
-          "0": [
-            0,
-            1,
-            2
-          ]
+          "a": {
+            "interface": 0
+          },
+          "b": {
+            "interface": 0
+          },
+          "c": {
+            "interface": 0
+          }
         },
         "exports": {
           "a": {
@@ -170,11 +175,15 @@
       {
         "id": "test:comp/w@0.0.1",
         "uses": {
-          "2": [
-            1,
-            2,
-            0
-          ]
+          "x": {
+            "interface": 2
+          },
+          "y": {
+            "interface": 2
+          },
+          "z": {
+            "interface": 2
+          }
         },
         "imports": {
           "x": {

--- a/crates/wac-parser/tests/resolution/package-world-include.wac.result
+++ b/crates/wac-parser/tests/resolution/package-world-include.wac.result
@@ -148,9 +148,9 @@
       {
         "id": "foo:bar/baz",
         "uses": {
-          "1": [
-            0
-          ]
+          "x": {
+            "interface": 1
+          }
         },
         "imports": {
           "foo:bar/i": {

--- a/crates/wac-parser/tests/resolution/types.wac.result
+++ b/crates/wac-parser/tests/resolution/types.wac.result
@@ -133,9 +133,13 @@
       {
         "id": "test:comp/i2",
         "uses": {
-          "0": [
-            1
-          ]
+          "r": {
+            "interface": 0
+          },
+          "z": {
+            "interface": 0,
+            "name": "r"
+          }
         },
         "exports": {
           "r": {
@@ -216,9 +220,9 @@
       {
         "id": "test:comp/w1",
         "uses": {
-          "2": [
-            0
-          ]
+          "r": {
+            "interface": 2
+          }
         },
         "imports": {
           "r": {

--- a/crates/wac-resolver/src/fs.rs
+++ b/crates/wac-resolver/src/fs.rs
@@ -117,7 +117,10 @@ impl FileSystemPackageResolver {
             }
 
             if !path.is_file() {
-                log::debug!("package `{path}` does not exist", path = path.display());
+                log::debug!(
+                    "package `{key}` does not exist at `{path}`",
+                    path = path.display()
+                );
                 if self.error_on_unknown {
                     return Err(Error::UnknownPackage {
                         name: key.name.to_string(),
@@ -127,7 +130,10 @@ impl FileSystemPackageResolver {
                 continue;
             }
 
-            log::debug!("loading package from `{path}`", path = path.display());
+            log::debug!(
+                "loading package `{key}` from `{path}`",
+                path = path.display()
+            );
             let bytes = fs::read(&path)
                 .with_context(|| format!("failed to read package `{path}`", path = path.display()))
                 .map_err(|e| Error::PackageResolutionFailure {


### PR DESCRIPTION
This PR fixes encoding of used types such that renamed types now properly encode.

Used types are now stored in a map from export/import name to used interface (along with the original export name when renamed).

Additionally, `todo!` placeholders were added for merging non-interface imports, which will be needed in the near future.

Also removed some redundant code in package decoding and improved the debug log output of the local package resolver.