### PR TITLE
Allow identifiers for import/export `as` clause.

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -321,7 +321,7 @@ package-decl ::= `package` package-name `;`
 package-name ::= id (':' id)+ ('@' version)?
 version      ::= <SEMVER>
 
-import-statement ::= 'import' id ('as' string)? ':' import-type ';'
+import-statement ::= 'import' id ('as' (id | string))? ':' import-type ';'
 import-type      ::= package-path | func-type | inline-interface | id
 package-path     ::= id (':' id)+ ('/' id)+ ('@' version)?
 
@@ -410,7 +410,7 @@ postfix-expr            ::= access-expr | named-access-expr
 access-expr             ::= '.' id
 named-access-expr       ::= '[' string ']'
 
-export-statement        ::= 'export' expr ('as' string)? ';'
+export-statement        ::= 'export' expr ('as' (id | string))? ';'
 
 id     ::= '%'?[a-z][a-z0-9]*('-'[a-z][a-z0-9]*)*
 string ::= '"' character-that-is-not-a-double-quote* '"'

--- a/crates/wac-parser/src/ast/export.rs
+++ b/crates/wac-parser/src/ast/export.rs
@@ -1,5 +1,6 @@
 use super::{
-    expr::Expr, parse_optional, parse_token, DocComment, Lookahead, Parse, ParseResult, Peek,
+    expr::Expr, parse_optional, parse_token, DocComment, ExternName, Lookahead, Parse, ParseResult,
+    Peek,
 };
 use crate::lexer::{Lexer, Token};
 use miette::SourceSpan;
@@ -14,7 +15,7 @@ pub struct ExportStatement<'a> {
     /// The span of the export keyword.
     pub span: SourceSpan,
     /// The optional name to use for the export.
-    pub name: Option<super::String<'a>>,
+    pub name: Option<ExternName<'a>>,
     /// The expression to export.
     pub expr: Expr<'a>,
 }

--- a/crates/wac-parser/src/ast/printer.rs
+++ b/crates/wac-parser/src/ast/printer.rs
@@ -84,7 +84,7 @@ impl<'a, W: Write> DocumentPrinter<'a, W> {
         )?;
 
         if let Some(name) = &statement.name {
-            write!(self.writer, " as {name}", name = self.source(name.span))?;
+            write!(self.writer, " as {name}", name = self.source(name.span()))?;
         }
 
         write!(self.writer, ": ")?;
@@ -752,7 +752,7 @@ impl<'a, W: Write> DocumentPrinter<'a, W> {
         self.expr(&stmt.expr)?;
 
         if let Some(name) = &stmt.name {
-            write!(self.writer, " as {name}", name = self.source(name.span))?;
+            write!(self.writer, " as {name}", name = self.source(name.span()))?;
         }
 
         write!(self.writer, ";")

--- a/crates/wac-parser/src/resolution/ast.rs
+++ b/crates/wac-parser/src/resolution/ast.rs
@@ -235,9 +235,9 @@ impl<'a> AstResolver<'a> {
             _ => kind,
         };
 
-        let (name, span) = if let Some(name) = stmt.name {
+        let (name, span) = if let Some(name) = &stmt.name {
             // Override the span to the `as` clause string
-            (name.value, name.span)
+            (name.as_str(), name.span())
         } else {
             // If the item is an instance with an id, use the id
             if let ItemKind::Instance(id) = kind {
@@ -359,8 +359,8 @@ impl<'a> AstResolver<'a> {
     ) -> ResolutionResult<()> {
         log::debug!("resolving export statement");
         let item = self.expr(state, &stmt.expr)?;
-        let (name, span) = if let Some(name) = stmt.name {
-            (name.value, name.span)
+        let (name, span) = if let Some(name) = &stmt.name {
+            (name.as_str(), name.span())
         } else {
             (
                 self.infer_export_name(state, item)

--- a/crates/wac-parser/tests/parser/export.wac
+++ b/crates/wac-parser/tests/parser/export.wac
@@ -6,5 +6,8 @@ export e;
 /// Export an alias of an item (default name)
 export e["foo"];
 
-/// Export an alias of an item with a different name
+/// Export an alias of an item with a different name with string
 export e["foo"] as "bar";
+
+/// Export an alias of an item with a different name with identifier
+export e["foo"] as foo-bar;

--- a/crates/wac-parser/tests/parser/export.wac.result
+++ b/crates/wac-parser/tests/parser/export.wac.result
@@ -90,22 +90,24 @@
       "Export": {
         "docs": [
           {
-            "comment": "Export an alias of an item with a different name",
+            "comment": "Export an alias of an item with a different name with string",
             "span": {
               "offset": 129,
-              "length": 52
+              "length": 64
             }
           }
         ],
         "span": {
-          "offset": 182,
+          "offset": 194,
           "length": 6
         },
         "name": {
-          "value": "bar",
-          "span": {
-            "offset": 201,
-            "length": 5
+          "string": {
+            "value": "bar",
+            "span": {
+              "offset": 213,
+              "length": 5
+            }
           }
         },
         "expr": {
@@ -113,7 +115,7 @@
             "ident": {
               "string": "e",
               "span": {
-                "offset": 189,
+                "offset": 201,
                 "length": 1
               }
             }
@@ -122,13 +124,67 @@
             {
               "namedAccess": {
                 "span": {
-                  "offset": 190,
+                  "offset": 202,
                   "length": 7
                 },
                 "string": {
                   "value": "foo",
                   "span": {
-                    "offset": 191,
+                    "offset": 203,
+                    "length": 5
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Export": {
+        "docs": [
+          {
+            "comment": "Export an alias of an item with a different name with identifier",
+            "span": {
+              "offset": 221,
+              "length": 68
+            }
+          }
+        ],
+        "span": {
+          "offset": 290,
+          "length": 6
+        },
+        "name": {
+          "ident": {
+            "string": "foo-bar",
+            "span": {
+              "offset": 309,
+              "length": 7
+            }
+          }
+        },
+        "expr": {
+          "primary": {
+            "ident": {
+              "string": "e",
+              "span": {
+                "offset": 297,
+                "length": 1
+              }
+            }
+          },
+          "postfix": [
+            {
+              "namedAccess": {
+                "span": {
+                  "offset": 298,
+                  "length": 7
+                },
+                "string": {
+                  "value": "foo",
+                  "span": {
+                    "offset": 299,
                     "length": 5
                   }
                 }

--- a/crates/wac-parser/tests/parser/import.wac
+++ b/crates/wac-parser/tests/parser/import.wac
@@ -9,7 +9,7 @@ import b: x;
 /// Import by package path
 import c: foo:bar/baz;
 
-/// Import by func type with kebab name 
+/// Import by func type with kebab name string
 import d as "hello-world": func(name: string);
 
 /// Import by inline interface
@@ -19,3 +19,6 @@ import e: interface {
 
 /// Import by package path with version
 import f: foo:bar/baz@1.0.0;
+
+/// Import by func type with kebab name identifier
+import g as hello-world: func(name: string);

--- a/crates/wac-parser/tests/parser/import.wac.result
+++ b/crates/wac-parser/tests/parser/import.wac.result
@@ -104,25 +104,27 @@
       "Import": {
         "docs": [
           {
-            "comment": "Import by func type with kebab name",
+            "comment": "Import by func type with kebab name string",
             "span": {
               "offset": 148,
-              "length": 40
+              "length": 46
             }
           }
         ],
         "id": {
           "string": "d",
           "span": {
-            "offset": 196,
+            "offset": 202,
             "length": 1
           }
         },
         "name": {
-          "value": "hello-world",
-          "span": {
-            "offset": 201,
-            "length": 13
+          "string": {
+            "value": "hello-world",
+            "span": {
+              "offset": 207,
+              "length": 13
+            }
           }
         },
         "ty": {
@@ -132,13 +134,13 @@
                 "id": {
                   "string": "name",
                   "span": {
-                    "offset": 221,
+                    "offset": 227,
                     "length": 4
                   }
                 },
                 "ty": {
                   "string": {
-                    "offset": 227,
+                    "offset": 233,
                     "length": 6
                   }
                 }
@@ -155,7 +157,7 @@
           {
             "comment": "Import by inline interface",
             "span": {
-              "offset": 237,
+              "offset": 243,
               "length": 30
             }
           }
@@ -163,7 +165,7 @@
         "id": {
           "string": "e",
           "span": {
-            "offset": 275,
+            "offset": 281,
             "length": 1
           }
         },
@@ -177,7 +179,7 @@
                   "id": {
                     "string": "x",
                     "span": {
-                      "offset": 294,
+                      "offset": 300,
                       "length": 1
                     }
                   },
@@ -200,7 +202,7 @@
           {
             "comment": "Import by package path with version",
             "span": {
-              "offset": 309,
+              "offset": 315,
               "length": 39
             }
           }
@@ -208,7 +210,7 @@
         "id": {
           "string": "f",
           "span": {
-            "offset": 356,
+            "offset": 362,
             "length": 1
           }
         },
@@ -216,13 +218,64 @@
         "ty": {
           "package": {
             "span": {
-              "offset": 359,
+              "offset": 365,
               "length": 17
             },
             "string": "foo:bar/baz@1.0.0",
             "name": "foo:bar",
             "segments": "baz",
             "version": "1.0.0"
+          }
+        }
+      }
+    },
+    {
+      "Import": {
+        "docs": [
+          {
+            "comment": "Import by func type with kebab name identifier",
+            "span": {
+              "offset": 385,
+              "length": 50
+            }
+          }
+        ],
+        "id": {
+          "string": "g",
+          "span": {
+            "offset": 443,
+            "length": 1
+          }
+        },
+        "name": {
+          "ident": {
+            "string": "hello-world",
+            "span": {
+              "offset": 448,
+              "length": 11
+            }
+          }
+        },
+        "ty": {
+          "func": {
+            "params": [
+              {
+                "id": {
+                  "string": "name",
+                  "span": {
+                    "offset": 466,
+                    "length": 4
+                  }
+                },
+                "ty": {
+                  "string": {
+                    "offset": 472,
+                    "length": 6
+                  }
+                }
+              }
+            ],
+            "results": "empty"
           }
         }
       }

--- a/crates/wac-parser/tests/resolution/fail/duplicate-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-export.wac
@@ -1,0 +1,6 @@
+package test:comp;
+
+import foo: func();
+
+export foo as "foo";
+export foo as foo;

--- a/crates/wac-parser/tests/resolution/fail/duplicate-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-export.wac.result
@@ -1,0 +1,12 @@
+failed to resolve document
+
+  × duplicate export `foo`
+   ╭─[tests/resolution/fail/duplicate-export.wac:6:15]
+ 4 │ 
+ 5 │ export foo as "foo";
+   ·               ──┬──
+   ·                 ╰── previous export here
+ 6 │ export foo as foo;
+   ·               ─┬─
+   ·                ╰── duplicate export name `foo`
+   ╰────

--- a/crates/wac-parser/tests/resolution/fail/duplicate-import.wac
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-import.wac
@@ -1,0 +1,4 @@
+package test:comp;
+
+import foo as "foo": func();
+import bar as foo: func();

--- a/crates/wac-parser/tests/resolution/fail/duplicate-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/duplicate-import.wac.result
@@ -1,0 +1,12 @@
+failed to resolve document
+
+  × duplicate import `foo`
+   ╭─[tests/resolution/fail/duplicate-import.wac:4:15]
+ 2 │ 
+ 3 │ import foo as "foo": func();
+   ·               ──┬──
+   ·                 ╰── previous import here
+ 4 │ import bar as foo: func();
+   ·               ─┬─
+   ·                ╰── duplicate import name `foo`
+   ╰────


### PR DESCRIPTION
This PR changes the WAC grammar to except identifiers in addition to strings in the `as` clause of import and export statements.

Partial fix for #10.