### PR TITLE
Implement the `targets` clause on the package directive.

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -409,7 +409,7 @@ statement ::= import-statement
             | let-statement
             | export-statement
 
-package-decl ::= `package` package-name `;`
+package-decl ::= `package` package-name (`targets` package-path)? `;`
 package-name ::= id (':' id)+ ('@' version)?
 version      ::= <SEMVER>
 

--- a/crates/wac-parser/src/ast/printer.rs
+++ b/crates/wac-parser/src/ast/printer.rs
@@ -30,12 +30,7 @@ impl<'a, W: Write> DocumentPrinter<'a, W> {
     /// Prints the given document.
     pub fn document(&mut self, doc: &Document) -> std::fmt::Result {
         self.docs(&doc.docs)?;
-        writeln!(
-            self.writer,
-            "package {package};",
-            package = self.source(doc.package.span),
-        )?;
-        self.newline()?;
+        self.package_directive(&doc.directive)?;
 
         for (i, statement) in doc.statements.iter().enumerate() {
             if i > 0 {
@@ -47,6 +42,24 @@ impl<'a, W: Write> DocumentPrinter<'a, W> {
         }
 
         Ok(())
+    }
+
+    /// Prints the given package directive.
+    pub fn package_directive(&mut self, directive: &PackageDirective) -> std::fmt::Result {
+        self.indent()?;
+        write!(
+            self.writer,
+            "package {package}",
+            package = self.source(directive.package.span),
+        )?;
+
+        if let Some(targets) = &directive.targets {
+            write!(self.writer, " ")?;
+            self.package_path(targets)?;
+        }
+
+        writeln!(self.writer, ";")?;
+        self.newline()
     }
 
     /// Prints the given statement.

--- a/crates/wac-parser/src/lexer.rs
+++ b/crates/wac-parser/src/lexer.rs
@@ -235,6 +235,9 @@ pub enum Token {
     /// The `package` keyword.
     #[token("package")]
     PackageKeyword,
+    /// The `targets` keyword.
+    #[token("targets")]
+    TargetsKeyword,
 
     /// The `;` symbol.
     #[token(";")]
@@ -338,6 +341,7 @@ impl fmt::Display for Token {
             Token::IncludeKeyword => write!(f, "`include` keyword"),
             Token::AsKeyword => write!(f, "`as` keyword"),
             Token::PackageKeyword => write!(f, "`package` keyword"),
+            Token::TargetsKeyword => write!(f, "`targets` keyword"),
             Token::Semicolon => write!(f, "`;`"),
             Token::OpenBrace => write!(f, "`{{`"),
             Token::CloseBrace => write!(f, "`}}`"),
@@ -827,6 +831,8 @@ let
 use
 include
 as
+package
+targets
             "#,
             &[
                 (Ok(Token::ImportKeyword), "import", 1..7),
@@ -866,6 +872,8 @@ as
                 (Ok(Token::UseKeyword), "use", 203..206),
                 (Ok(Token::IncludeKeyword), "include", 207..214),
                 (Ok(Token::AsKeyword), "as", 215..217),
+                (Ok(Token::PackageKeyword), "package", 218..225),
+                (Ok(Token::TargetsKeyword), "targets", 226..233),
             ],
         );
     }

--- a/crates/wac-parser/src/resolution.rs
+++ b/crates/wac-parser/src/resolution.rs
@@ -682,25 +682,27 @@ pub enum Error {
         span: SourceSpan,
     },
     /// An import is not in the target world.
-    #[error("import `{name}` is not present in target world `{world}`")]
+    #[error("target world `{world}` does not have an import named `{name}`")]
     ImportNotInTarget {
         /// The import name.
         name: String,
         /// The target world.
         world: String,
         /// The span where the error occurred.
-        #[label(primary, "import `{name}` is not in the target world")]
+        #[label(primary, "cannot have an import named `{name}`")]
         span: SourceSpan,
     },
     /// Missing an export for the target world.
-    #[error("missing export `{name}` for target world `{world}`")]
+    #[error("target world `{world}` requires an export named `{name}`")]
     MissingTargetExport {
         /// The export name.
         name: String,
+        /// The expected item kind.
+        kind: String,
         /// The target world.
         world: String,
         /// The span where the error occurred.
-        #[label(primary, "must export `{name}` to target this world")]
+        #[label(primary, "must export a {kind} named `{name}` to target this world")]
         span: SourceSpan,
     },
     /// An import or export has a mismatched type for the target world.

--- a/crates/wac-parser/src/resolution/ast.rs
+++ b/crates/wac-parser/src/resolution/ast.rs
@@ -181,11 +181,29 @@ impl<'a> AstResolver<'a> {
             }
         }
 
+        // If there's a target world in the directive, validate the composition
+        // conforms to the target
+        if let Some(path) = &self.document.directive.targets {
+            let item = self.resolve_package_export(&mut state, path)?;
+            match item {
+                ItemKind::Type(Type::World(world)) => {
+                    self.validate_target(&state, path, world)?;
+                }
+                _ => {
+                    return Err(Error::NotWorld {
+                        name: path.string.to_owned(),
+                        kind: item.as_str(&self.definitions).to_owned(),
+                        span: path.span,
+                    });
+                }
+            }
+        }
+
         assert!(state.scopes.is_empty());
 
         Ok(Composition {
-            package: self.document.package.name.to_owned(),
-            version: self.document.package.version.clone(),
+            package: self.document.directive.package.name.to_owned(),
+            version: self.document.directive.package.version.clone(),
             definitions: self.definitions,
             packages: state.packages,
             items: state.current.items,
@@ -227,13 +245,8 @@ impl<'a> AstResolver<'a> {
             ast::ImportType::Ident(id) => (state.local_item(id)?.1.kind(), stmt.id.span),
         };
 
-        // Promote function types, instance types, and component types to functions, instances, and components
-        let kind = match kind {
-            ItemKind::Type(Type::Func(id)) => ItemKind::Func(id),
-            ItemKind::Type(Type::Interface(id)) => ItemKind::Instance(id),
-            ItemKind::Type(Type::World(id)) => ItemKind::Component(id),
-            _ => kind,
-        };
+        // Promote any types to their corresponding item kind
+        let kind = kind.promote();
 
         let (name, span) = if let Some(name) = &stmt.name {
             // Override the span to the `as` clause string
@@ -505,8 +518,8 @@ impl<'a> AstResolver<'a> {
     fn id(&self, name: &str) -> String {
         format!(
             "{pkg}/{name}{version}",
-            pkg = self.document.package.name,
-            version = if let Some(version) = &self.document.package.version {
+            pkg = self.document.directive.package.name,
+            version = if let Some(version) = &self.document.directive.package.version {
                 format!("@{version}")
             } else {
                 String::new()
@@ -1551,7 +1564,7 @@ impl<'a> AstResolver<'a> {
         path: &'a ast::PackagePath<'a>,
     ) -> ResolutionResult<ItemKind> {
         // Check for reference to local item
-        if path.name == self.document.package.name {
+        if path.name == self.document.directive.package.name {
             return self.resolve_local_export(state, path);
         }
 
@@ -1704,7 +1717,7 @@ impl<'a> AstResolver<'a> {
         state: &mut State<'a>,
         expr: &'a ast::NewExpr<'a>,
     ) -> ResolutionResult<ItemId> {
-        if expr.package.name == self.document.package.name {
+        if expr.package.name == self.document.directive.package.name {
             return Err(Error::UnknownPackage {
                 name: expr.package.name.to_string(),
                 span: expr.package.span,
@@ -2247,5 +2260,68 @@ impl<'a> AstResolver<'a> {
 
         aliases.insert(name.to_owned(), id);
         Ok(Some(id))
+    }
+
+    fn validate_target(
+        &self,
+        state: &State,
+        path: &ast::PackagePath,
+        world: WorldId,
+    ) -> ResolutionResult<()> {
+        let world = &self.definitions.worlds[world];
+
+        let mut checker = SubtypeChecker::new(&self.definitions, &state.packages);
+
+        // The output is allowed to import a subset of the world's imports
+        for (name, import) in &state.imports {
+            let expected = world
+                .imports
+                .get(name)
+                .ok_or_else(|| Error::ImportNotInTarget {
+                    name: name.clone(),
+                    world: path.string.to_owned(),
+                    span: import.span,
+                })?;
+
+            checker
+                .is_subtype(
+                    expected.promote(),
+                    state.root_scope().items[import.item].kind(),
+                )
+                .map_err(|e| Error::TargetMismatch {
+                    kind: ExternKind::Import,
+                    name: name.clone(),
+                    world: path.string.to_owned(),
+                    span: import.span,
+                    source: e,
+                })?;
+        }
+
+        // The output must export every export in the world
+        for (name, expected) in &world.exports {
+            let export = state
+                .exports
+                .get(name)
+                .ok_or_else(|| Error::MissingTargetExport {
+                    name: name.clone(),
+                    world: path.string.to_owned(),
+                    span: path.span,
+                })?;
+
+            checker
+                .is_subtype(
+                    expected.promote(),
+                    state.root_scope().items[export.item].kind(),
+                )
+                .map_err(|e| Error::TargetMismatch {
+                    kind: ExternKind::Export,
+                    name: name.clone(),
+                    world: path.string.to_owned(),
+                    span: export.span,
+                    source: e,
+                })?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/wac-parser/src/resolution/ast.rs
+++ b/crates/wac-parser/src/resolution/ast.rs
@@ -2305,6 +2305,7 @@ impl<'a> AstResolver<'a> {
                 .ok_or_else(|| Error::MissingTargetExport {
                     name: name.clone(),
                     world: path.string.to_owned(),
+                    kind: expected.as_str(&self.definitions).to_string(),
                     span: path.span,
                 })?;
 

--- a/crates/wac-parser/tests/parser/export.wac.result
+++ b/crates/wac-parser/tests/parser/export.wac.result
@@ -1,12 +1,14 @@
 {
   "docs": [],
-  "package": {
-    "string": "test:comp",
-    "name": "test:comp",
-    "version": null,
-    "span": {
-      "offset": 8,
-      "length": 9
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
     }
   },
   "statements": [

--- a/crates/wac-parser/tests/parser/import.wac.result
+++ b/crates/wac-parser/tests/parser/import.wac.result
@@ -1,12 +1,14 @@
 {
   "docs": [],
-  "package": {
-    "string": "test:comp",
-    "name": "test:comp",
-    "version": null,
-    "span": {
-      "offset": 8,
-      "length": 9
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
     }
   },
   "statements": [

--- a/crates/wac-parser/tests/parser/let.wac.result
+++ b/crates/wac-parser/tests/parser/let.wac.result
@@ -1,12 +1,14 @@
 {
   "docs": [],
-  "package": {
-    "string": "test:comp",
-    "name": "test:comp",
-    "version": null,
-    "span": {
-      "offset": 8,
-      "length": 9
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
     }
   },
   "statements": [

--- a/crates/wac-parser/tests/parser/resource.wac.result
+++ b/crates/wac-parser/tests/parser/resource.wac.result
@@ -1,12 +1,14 @@
 {
   "docs": [],
-  "package": {
-    "string": "test:comp",
-    "name": "test:comp",
-    "version": null,
-    "span": {
-      "offset": 8,
-      "length": 9
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
     }
   },
   "statements": [

--- a/crates/wac-parser/tests/parser/type-alias.wac.result
+++ b/crates/wac-parser/tests/parser/type-alias.wac.result
@@ -1,12 +1,14 @@
 {
   "docs": [],
-  "package": {
-    "string": "test:comp",
-    "name": "test:comp",
-    "version": null,
-    "span": {
-      "offset": 8,
-      "length": 9
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
     }
   },
   "statements": [

--- a/crates/wac-parser/tests/parser/types.wac.result
+++ b/crates/wac-parser/tests/parser/types.wac.result
@@ -1,12 +1,14 @@
 {
   "docs": [],
-  "package": {
-    "string": "test:comp",
-    "name": "test:comp",
-    "version": null,
-    "span": {
-      "offset": 8,
-      "length": 9
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
     }
   },
   "statements": [

--- a/crates/wac-parser/tests/resolution/fail/missing-target-export.wac
+++ b/crates/wac-parser/tests/resolution/fail/missing-target-export.wac
@@ -1,0 +1,1 @@
+package test:comp targets foo:bar/baz;

--- a/crates/wac-parser/tests/resolution/fail/missing-target-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-target-export.wac.result
@@ -1,8 +1,8 @@
 failed to resolve document
 
-  × missing export `hello` for target world `foo:bar/baz`
+  × target world `foo:bar/baz` requires an export named `hello`
    ╭─[tests/resolution/fail/missing-target-export.wac:1:27]
  1 │ package test:comp targets foo:bar/baz;
    ·                           ─────┬─────
-   ·                                ╰── must export `hello` to target this world
+   ·                                ╰── must export a function named `hello` to target this world
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/missing-target-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-target-export.wac.result
@@ -1,0 +1,8 @@
+failed to resolve document
+
+  × missing export `hello` for target world `foo:bar/baz`
+   ╭─[tests/resolution/fail/missing-target-export.wac:1:27]
+ 1 │ package test:comp targets foo:bar/baz;
+   ·                           ─────┬─────
+   ·                                ╰── must export `hello` to target this world
+   ╰────

--- a/crates/wac-parser/tests/resolution/fail/missing-target-export/foo/bar/bar.wit
+++ b/crates/wac-parser/tests/resolution/fail/missing-target-export/foo/bar/bar.wit
@@ -1,0 +1,5 @@
+package foo:bar;
+
+world baz {
+    export hello: func() -> string;
+}

--- a/crates/wac-parser/tests/resolution/fail/target-export-mismatch.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-export-mismatch.wac
@@ -1,0 +1,15 @@
+package test:comp targets test:comp/world;
+
+world %world {
+    import foo: interface {
+        foo: func(x: u32);
+    };
+    export foo: interface {
+        foo: func(x: string);
+    };
+}
+
+import foo: interface {
+    foo: func(x: u32);
+};
+export foo;

--- a/crates/wac-parser/tests/resolution/fail/target-export-mismatch.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-export-mismatch.wac.result
@@ -1,0 +1,12 @@
+failed to resolve document
+
+  × export `foo` has a mismatched type for target world `test:comp/world`
+  ├─▶ mismatched type for export `foo`
+  ├─▶ mismatched type for function parameter `x`
+  ╰─▶ expected string, found u32
+    ╭─[tests/resolution/fail/target-export-mismatch.wac:15:8]
+ 14 │ };
+ 15 │ export foo;
+    ·        ─┬─
+    ·         ╰── mismatched type for export `foo`
+    ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-extraneous-import.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-extraneous-import.wac
@@ -1,0 +1,7 @@
+package test:comp targets test:comp/foo;
+
+world foo {
+    import foo: func();
+}
+
+import bar: func();

--- a/crates/wac-parser/tests/resolution/fail/target-extraneous-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-extraneous-import.wac.result
@@ -1,9 +1,9 @@
 failed to resolve document
 
-  × import `bar` is not present in target world `test:comp/foo`
+  × target world `test:comp/foo` does not have an import named `bar`
    ╭─[tests/resolution/fail/target-extraneous-import.wac:7:8]
  6 │ 
  7 │ import bar: func();
    ·        ─┬─
-   ·         ╰── import `bar` is not in the target world
+   ·         ╰── cannot have an import named `bar`
    ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-extraneous-import.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-extraneous-import.wac.result
@@ -1,0 +1,9 @@
+failed to resolve document
+
+  × import `bar` is not present in target world `test:comp/foo`
+   ╭─[tests/resolution/fail/target-extraneous-import.wac:7:8]
+ 6 │ 
+ 7 │ import bar: func();
+   ·        ─┬─
+   ·         ╰── import `bar` is not in the target world
+   ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-import-mismatch.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-import-mismatch.wac
@@ -1,0 +1,9 @@
+package test:comp targets test:comp/foo;
+
+world foo {
+    import foo: func();
+}
+
+import foo2 as foo: interface {
+
+};

--- a/crates/wac-parser/tests/resolution/fail/target-import-mismatch.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-import-mismatch.wac.result
@@ -1,0 +1,11 @@
+failed to resolve document
+
+  × import `foo` has a mismatched type for target world `test:comp/foo`
+  ╰─▶ expected function, found instance
+   ╭─[tests/resolution/fail/target-import-mismatch.wac:7:16]
+ 6 │ 
+ 7 │ import foo2 as foo: interface {
+   ·                ─┬─
+   ·                 ╰── mismatched type for import `foo`
+ 8 │ 
+   ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-is-not-a-world.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-is-not-a-world.wac
@@ -1,0 +1,4 @@
+package test:comp targets test:comp/foo;
+
+interface foo {   
+}

--- a/crates/wac-parser/tests/resolution/fail/target-is-not-a-world.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-is-not-a-world.wac.result
@@ -1,0 +1,9 @@
+failed to resolve document
+
+  × `test:comp/foo` (interface) is not a world
+   ╭─[tests/resolution/fail/target-is-not-a-world.wac:1:27]
+ 1 │ package test:comp targets test:comp/foo;
+   ·                           ──────┬──────
+   ·                                 ╰── `test:comp/foo` is not a world
+ 2 │ 
+   ╰────

--- a/crates/wac-parser/tests/resolution/fail/unknown-target-path.wac
+++ b/crates/wac-parser/tests/resolution/fail/unknown-target-path.wac
@@ -1,0 +1,1 @@
+package test:comp targets foo:bar/baz;

--- a/crates/wac-parser/tests/resolution/fail/unknown-target-path.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/unknown-target-path.wac.result
@@ -1,0 +1,8 @@
+failed to resolve document
+
+  × unknown package `foo:bar`
+   ╭─[tests/resolution/fail/unknown-target-path.wac:1:27]
+ 1 │ package test:comp targets foo:bar/baz;
+   ·                           ───┬───
+   ·                              ╰── unknown package `foo:bar`
+   ╰────

--- a/crates/wac-parser/tests/resolution/fail/unknown-targets-path.wac
+++ b/crates/wac-parser/tests/resolution/fail/unknown-targets-path.wac
@@ -1,0 +1,1 @@
+package test:comp targets test:comp/foo;

--- a/crates/wac-parser/tests/resolution/fail/unknown-targets-path.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/unknown-targets-path.wac.result
@@ -1,0 +1,8 @@
+failed to resolve document
+
+  × undefined name `foo`
+   ╭─[tests/resolution/fail/unknown-targets-path.wac:1:37]
+ 1 │ package test:comp targets test:comp/foo;
+   ·                                     ─┬─
+   ·                                      ╰── undefined name `foo`
+   ╰────

--- a/crates/wac-parser/tests/resolution/targets-empty-world.wac
+++ b/crates/wac-parser/tests/resolution/targets-empty-world.wac
@@ -1,0 +1,4 @@
+package test:comp targets test:comp/foo;
+
+world foo {   
+}

--- a/crates/wac-parser/tests/resolution/targets-empty-world.wac.result
+++ b/crates/wac-parser/tests/resolution/targets-empty-world.wac.result
@@ -1,0 +1,36 @@
+{
+  "package": "test:comp",
+  "version": null,
+  "definitions": {
+    "types": [],
+    "resources": [],
+    "funcs": [],
+    "interfaces": [],
+    "worlds": [
+      {
+        "id": "test:comp/foo",
+        "uses": {},
+        "imports": {},
+        "exports": {}
+      }
+    ],
+    "modules": []
+  },
+  "packages": [],
+  "items": [
+    {
+      "definition": {
+        "name": "foo",
+        "kind": {
+          "type": {
+            "world": 0
+          }
+        }
+      }
+    }
+  ],
+  "imports": {},
+  "exports": {
+    "foo": 0
+  }
+}

--- a/crates/wac-parser/tests/resolution/targets-world.wac
+++ b/crates/wac-parser/tests/resolution/targets-world.wac
@@ -1,0 +1,12 @@
+package test:comp targets test:comp/world;
+
+world %world {
+    import f: func();
+    export i: interface {
+        f: func();
+    };
+}
+
+import f: func();
+
+export new foo:bar { f } as i;

--- a/crates/wac-parser/tests/resolution/targets-world.wac.result
+++ b/crates/wac-parser/tests/resolution/targets-world.wac.result
@@ -1,0 +1,113 @@
+{
+  "package": "test:comp",
+  "version": null,
+  "definitions": {
+    "types": [],
+    "resources": [],
+    "funcs": [
+      {
+        "params": {},
+        "results": null
+      },
+      {
+        "params": {},
+        "results": null
+      },
+      {
+        "params": {},
+        "results": null
+      },
+      {
+        "params": {},
+        "results": null
+      }
+    ],
+    "interfaces": [
+      {
+        "id": null,
+        "uses": {},
+        "exports": {
+          "f": {
+            "func": 1
+          }
+        }
+      }
+    ],
+    "worlds": [
+      {
+        "id": "test:comp/world",
+        "uses": {},
+        "imports": {
+          "f": {
+            "func": 0
+          }
+        },
+        "exports": {
+          "i": {
+            "type": {
+              "interface": 0
+            }
+          }
+        }
+      },
+      {
+        "id": null,
+        "uses": {},
+        "imports": {
+          "f": {
+            "func": 3
+          }
+        },
+        "exports": {
+          "f": {
+            "func": 3
+          }
+        }
+      }
+    ],
+    "modules": []
+  },
+  "packages": [
+    {
+      "name": "foo:bar",
+      "version": null,
+      "world": 1,
+      "definitions": {}
+    }
+  ],
+  "items": [
+    {
+      "definition": {
+        "name": "world",
+        "kind": {
+          "type": {
+            "world": 0
+          }
+        }
+      }
+    },
+    {
+      "import": {
+        "name": "f",
+        "kind": {
+          "func": 2
+        }
+      }
+    },
+    {
+      "instantiation": {
+        "package": 0,
+        "arguments": {
+          "f": 1
+        }
+      }
+    }
+  ],
+  "imports": {
+    "f": 1
+  },
+  "exports": {
+    "world": 0,
+    "i": 2
+  }
+}

--- a/crates/wac-parser/tests/resolution/targets-world/foo/bar.wat
+++ b/crates/wac-parser/tests/resolution/targets-world/foo/bar.wat
@@ -1,0 +1,4 @@
+(component
+  (import "f" (func))
+  (export "f" (func 0))
+)

--- a/crates/wac-resolver/src/lib.rs
+++ b/crates/wac-resolver/src/lib.rs
@@ -124,6 +124,10 @@ pub fn packages<'a>(
 ) -> Result<IndexMap<PackageKey<'a>, SourceSpan>, Error> {
     let mut keys = IndexMap::new();
     let mut visitor = PackageVisitor::new(|name, version, span| {
+        if name == document.directive.package.name {
+            return true;
+        }
+
         if keys.insert(PackageKey { name, version }, span).is_none() {
             if let Some(version) = version {
                 log::debug!("discovered reference to package `{name}` ({version})");

--- a/crates/wac-resolver/src/visitor.rs
+++ b/crates/wac-resolver/src/visitor.rs
@@ -30,6 +30,16 @@ where
     /// The package names are visited in-order and will not deduplicate
     /// names/versions that are referenced multiple times.
     pub fn visit(&mut self, doc: &'a Document) -> Result<(), Error> {
+        if let Some(targets) = &doc.directive.targets {
+            if !(self.0)(
+                targets.name,
+                targets.version.as_ref(),
+                targets.package_name_span(),
+            ) {
+                return Ok(());
+            }
+        }
+
         for stmt in &doc.statements {
             match stmt {
                 Statement::Import(i) => {
@@ -43,12 +53,12 @@ where
                     }
                 }
                 Statement::Let(l) => {
-                    if !self.expr(doc.package.name, &l.expr)? {
+                    if !self.expr(doc.directive.package.name, &l.expr)? {
                         break;
                     }
                 }
                 Statement::Export(e) => {
-                    if !self.expr(doc.package.name, &e.expr)? {
+                    if !self.expr(doc.directive.package.name, &e.expr)? {
                         break;
                     }
                 }


### PR DESCRIPTION
This PR implements the `targets` clause on the package directive.

When this clause is present, the parser will validate that the output composition is capable of targeting the world, otherwise it will emit an error.

Closes #20.