### PR TITLE
Provide a clearer error message when package is not component

### DIFF
--- a/crates/wac-parser/src/resolution/package.rs
+++ b/crates/wac-parser/src/resolution/package.rs
@@ -62,6 +62,9 @@ impl Package {
         version: Option<&Version>,
         bytes: Arc<Vec<u8>>,
     ) -> Result<Self> {
+        if !has_magic_header(&bytes) {
+            bail!("package `{name}` is expected to be a binary WebAssembly component binary but is not");
+        }
         let mut parser = Parser::new(0);
         let mut parsers = Vec::new();
         let mut validator = Validator::new_with_features(WasmFeatures {
@@ -180,6 +183,11 @@ impl Package {
 
         defs
     }
+}
+
+/// Whether the given bytes have a magic header indicating a WebAssembly binary.
+fn has_magic_header(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"\0asm")
 }
 
 impl fmt::Debug for Package {

--- a/crates/wac-parser/tests/resolution/fail/package-not-wasm.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/package-not-wasm.wac.result
@@ -1,17 +1,7 @@
 failed to resolve document
 
   × failed to parse package `foo:bar`
-  ╰─▶ magic header not detected: bad magic number - expected=[
-          0x0,
-          0x61,
-          0x73,
-          0x6d,
-      ] actual=[
-          0x74,
-          0x68,
-          0x69,
-          0x73,
-      ] (at offset 0x0)
+  ╰─▶ package `foo:bar` is expected to be a binary WebAssembly component binary but is not
    ╭─[tests/resolution/fail/package-not-wasm.wac:3:13]
  2 │ 
  3 │ import foo: foo:bar/qux;


### PR DESCRIPTION
One could argue that we just need to make the `wasmparser::Parser` error clearer, but I think it makes more sense for the higher-level error message to originate here. 