### PR TITLE
Allow single file wit packages

### DIFF
--- a/crates/wac-parser/src/ast/import.rs
+++ b/crates/wac-parser/src/ast/import.rs
@@ -118,7 +118,7 @@ impl<'a> Parse<'a> for ImportType<'a> {
     }
 }
 
-/// Represents a package path in the AST.
+/// AST representation of a path to an item such as a world in a package (e.g. `foo:bar/qux`).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackagePath<'a> {

--- a/crates/wac-parser/src/resolution/ast.rs
+++ b/crates/wac-parser/src/resolution/ast.rs
@@ -184,6 +184,7 @@ impl<'a> AstResolver<'a> {
         // If there's a target world in the directive, validate the composition
         // conforms to the target
         if let Some(path) = &self.document.directive.targets {
+            log::debug!("validating composition targets world `{}`", path.string);
             let item = self.resolve_package_export(&mut state, path)?;
             match item {
                 ItemKind::Type(Type::World(world)) => {
@@ -1563,6 +1564,7 @@ impl<'a> AstResolver<'a> {
         state: &mut State<'a>,
         path: &'a ast::PackagePath<'a>,
     ) -> ResolutionResult<ItemKind> {
+        log::debug!("resolving package export `{}`", path.string);
         // Check for reference to local item
         if path.name == self.document.directive.package.name {
             return self.resolve_local_export(state, path);

--- a/crates/wac-resolver/src/fs.rs
+++ b/crates/wac-resolver/src/fs.rs
@@ -114,6 +114,15 @@ impl FileSystemPackageResolver {
                 );
 
                 continue;
+            } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("wit") {
+                return Err(Error::PackageResolutionFailure {
+                    name: key.name.to_string(),
+                    span: *span,
+                    source: anyhow!(
+                        "WIT packages must be directories, not files: `{path}`",
+                        path = path.display()
+                    ),
+                });
             }
 
             if !path.is_file() {

--- a/crates/wac-resolver/src/fs.rs
+++ b/crates/wac-resolver/src/fs.rs
@@ -79,50 +79,46 @@ impl FileSystemPackageResolver {
             // First check to see if a directory exists.
             // If so, then treat it as a textual WIT package.
             #[cfg(feature = "wit")]
-            if path.is_dir() {
-                log::debug!(
-                    "loading WIT package from directory `{path}`",
-                    path = path.display()
-                );
-
-                let mut resolve = wit_parser::Resolve::new();
-                let (pkg, _) =
-                    resolve
-                        .push_dir(&path)
-                        .map_err(|e| Error::PackageResolutionFailure {
-                            name: key.name.to_string(),
-                            span: *span,
-                            source: e,
-                        })?;
-
-                packages.insert(
-                    *key,
-                    Arc::new(
-                        wit_component::encode(Some(true), &resolve, pkg)
-                            .with_context(|| {
-                                format!(
-                                    "failed to encode WIT package from directory `{path}`",
-                                    path = path.display()
-                                )
-                            })
-                            .map_err(|e| Error::PackageResolutionFailure {
-                                name: key.name.to_string(),
-                                span: *span,
-                                source: e,
-                            })?,
-                    ),
-                );
-
-                continue;
-            } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("wit") {
-                return Err(Error::PackageResolutionFailure {
+            {
+                let pkg_res_failure = |e| Error::PackageResolutionFailure {
                     name: key.name.to_string(),
                     span: *span,
-                    source: anyhow!(
-                        "WIT packages must be directories, not files: `{path}`",
+                    source: e,
+                };
+                let mut resolve = wit_parser::Resolve::new();
+                let pkg = if path.is_dir() {
+                    log::debug!(
+                        "loading WIT package from directory `{path}`",
                         path = path.display()
-                    ),
-                });
+                    );
+
+                    let (pkg, _) = resolve.push_dir(&path).map_err(pkg_res_failure)?;
+                    Some(pkg)
+                } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("wit") {
+                    let unresolved = wit_parser::UnresolvedPackage::parse_file(&path)
+                        .map_err(pkg_res_failure)?;
+                    let pkg = resolve.push(unresolved).map_err(pkg_res_failure)?;
+                    Some(pkg)
+                } else {
+                    None
+                };
+                if let Some(pkg) = pkg {
+                    packages.insert(
+                        *key,
+                        Arc::new(
+                            wit_component::encode(Some(true), &resolve, pkg)
+                                .with_context(|| {
+                                    format!(
+                                        "failed to encode WIT package from `{path}`",
+                                        path = path.display()
+                                    )
+                                })
+                                .map_err(pkg_res_failure)?,
+                        ),
+                    );
+
+                    continue;
+                }
             }
 
             if !path.is_file() {


### PR DESCRIPTION
Fixes #44 

This allows for a single wit file to be used as a package.

(I added a few logs that helped me in debugging and I changed a doc comment which would have helped me with some confusion - let me know if you'd rather I remove these unrelated changes.)