### PR TITLE
Improve subtype check.

### DIFF
--- a/crates/wac-parser/src/ast/expr.rs
+++ b/crates/wac-parser/src/ast/expr.rs
@@ -38,7 +38,7 @@ impl<'a> Parse<'a> for Expr<'a> {
 
         let start = primary.span();
         let len = postfix.last().map_or(start.len(), |p| {
-            start.offset() + p.span().offset() + p.span().len()
+            p.span().offset() + p.span().len() - start.offset()
         });
 
         Ok(Self {

--- a/crates/wac-parser/src/resolution/ast.rs
+++ b/crates/wac-parser/src/resolution/ast.rs
@@ -1534,8 +1534,8 @@ impl<'a> AstResolver<'a> {
             hash_map::Entry::Occupied(e) => Ok(*e.get()),
             hash_map::Entry::Vacant(e) => {
                 log::debug!("resolving package `{name}`");
-                let bytes = match self.packages.remove(&PackageKey { name, version }) {
-                    Some(bytes) => bytes,
+                let bytes = match self.packages.get(&PackageKey { name, version }) {
+                    Some(bytes) => bytes.clone(),
                     None => {
                         return Err(Error::UnknownPackage {
                             name: name.to_string(),
@@ -1788,7 +1788,7 @@ impl<'a> AstResolver<'a> {
             );
 
             SubtypeChecker::new(&self.definitions, &state.packages)
-                .is_subtype(*expected, state.current.items[*item].kind())
+                .is_subtype(state.current.items[*item].kind(), *expected)
                 .map_err(|e| Error::MismatchedInstantiationArg {
                     name: name.clone(),
                     span: *span,
@@ -1965,10 +1965,10 @@ impl<'a> AstResolver<'a> {
 
                     match (
                         checker
-                            .is_subtype(*target_kind, *source_kind)
+                            .is_subtype(*source_kind, *target_kind)
                             .with_context(|| format!("mismatched type for export `{name}`")),
                         checker
-                            .is_subtype(*source_kind, *target_kind)
+                            .is_subtype(*target_kind, *source_kind)
                             .with_context(|| format!("mismatched type for export `{name}`")),
                     ) {
                         (Ok(_), Ok(_)) => {
@@ -2273,6 +2273,7 @@ impl<'a> AstResolver<'a> {
         let mut checker = SubtypeChecker::new(&self.definitions, &state.packages);
 
         // The output is allowed to import a subset of the world's imports
+        checker.invert();
         for (name, import) in &state.imports {
             let expected = world
                 .imports
@@ -2297,6 +2298,8 @@ impl<'a> AstResolver<'a> {
                 })?;
         }
 
+        checker.revert();
+
         // The output must export every export in the world
         for (name, expected) in &world.exports {
             let export = state
@@ -2311,8 +2314,8 @@ impl<'a> AstResolver<'a> {
 
             checker
                 .is_subtype(
-                    expected.promote(),
                     state.root_scope().items[export.item].kind(),
+                    expected.promote(),
                 )
                 .map_err(|e| Error::TargetMismatch {
                     kind: ExternKind::Export,

--- a/crates/wac-parser/src/resolution/types.rs
+++ b/crates/wac-parser/src/resolution/types.rs
@@ -963,16 +963,16 @@ impl<'a> SubtypeChecker<'a> {
         let (expected, found) = self.expected_found(a, b);
         match (&expected.results, &found.results) {
             (Some(FuncResult::List(_)), Some(FuncResult::Scalar(_))) => {
-                bail!("expected function with named results, found function with scalar result")
+                bail!("expected function that returns a named result, found function with a single result type")
             }
             (Some(FuncResult::Scalar(_)), Some(FuncResult::List(_))) => {
-                bail!("expected function with scalar result, found function with named results")
+                bail!("expected function that returns a single result type, found function that returns a named result")
             }
             (Some(_), None) => {
-                bail!("expected function with results, found function without results")
+                bail!("expected function with a result, found function without a result")
             }
             (None, Some(_)) => {
-                bail!("expected function without results, found function with results")
+                bail!("expected function without a result, found function with a result")
             }
             (Some(FuncResult::Scalar(_)), Some(FuncResult::Scalar(_)))
             | (Some(FuncResult::List(_)), Some(FuncResult::List(_)))

--- a/crates/wac-parser/tests/parser/export.wac.result
+++ b/crates/wac-parser/tests/parser/export.wac.result
@@ -56,7 +56,7 @@
         "expr": {
           "span": {
             "offset": 118,
-            "length": 244
+            "length": 8
           },
           "primary": {
             "ident": {
@@ -102,7 +102,7 @@
         "expr": {
           "span": {
             "offset": 201,
-            "length": 410
+            "length": 8
           },
           "primary": {
             "ident": {
@@ -158,7 +158,7 @@
         "expr": {
           "span": {
             "offset": 297,
-            "length": 602
+            "length": 8
           },
           "primary": {
             "ident": {

--- a/crates/wac-parser/tests/parser/let.wac.result
+++ b/crates/wac-parser/tests/parser/let.wac.result
@@ -417,7 +417,7 @@
         "expr": {
           "span": {
             "offset": 424,
-            "length": 877
+            "length": 29
           },
           "primary": {
             "ident": {

--- a/crates/wac-parser/tests/resolution/fail/expected-result-named.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/expected-result-named.wac.result
@@ -2,7 +2,7 @@ failed to resolve document
 
   × mismatched instantiation argument `x`
   ├─▶ mismatched type for export `f`
-  ╰─▶ expected function with named results, found function with scalar result
+  ╰─▶ expected function that returns a named result, found function with a single result type
    ╭─[tests/resolution/fail/expected-result-named.wac:7:23]
  6 │ 
  7 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/expected-result-scalar.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/expected-result-scalar.wac.result
@@ -2,7 +2,7 @@ failed to resolve document
 
   × mismatched instantiation argument `x`
   ├─▶ mismatched type for export `f`
-  ╰─▶ expected function with scalar result, found function with named results
+  ╰─▶ expected function that returns a single result type, found function that returns a named result
    ╭─[tests/resolution/fail/expected-result-scalar.wac:7:23]
  6 │ 
  7 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/func-results-not-present.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/func-results-not-present.wac.result
@@ -2,7 +2,7 @@ failed to resolve document
 
   × mismatched instantiation argument `x`
   ├─▶ mismatched type for export `f`
-  ╰─▶ expected function with results, found function without results
+  ╰─▶ expected function with a result, found function without a result
    ╭─[tests/resolution/fail/func-results-not-present.wac:7:23]
  6 │ 
  7 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/func-results-present.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/func-results-present.wac.result
@@ -2,7 +2,7 @@ failed to resolve document
 
   × mismatched instantiation argument `x`
   ├─▶ mismatched type for export `f`
-  ╰─▶ expected function without results, found function with results
+  ╰─▶ expected function without a result, found function with a result
    ╭─[tests/resolution/fail/func-results-present.wac:7:23]
  6 │ 
  7 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/missing-constructor.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-constructor.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × mismatched instantiation argument `x`
-  ╰─▶ instance is missing expected export `[constructor]r`
+  ╰─▶ instance is missing expected function export `[constructor]r`
    ╭─[tests/resolution/fail/missing-constructor.wac:8:23]
  7 │ 
  8 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/missing-interface-export.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-interface-export.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × mismatched instantiation argument `x`
-  ╰─▶ instance is missing expected export `f`
+  ╰─▶ instance is missing expected function export `f`
    ╭─[tests/resolution/fail/missing-interface-export.wac:6:23]
  5 │ 
  6 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/missing-method.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-method.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × mismatched instantiation argument `x`
-  ╰─▶ instance is missing expected export `[method]r.foo`
+  ╰─▶ instance is missing expected function export `[method]r.foo`
    ╭─[tests/resolution/fail/missing-method.wac:8:23]
  7 │ 
  8 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/missing-static-method.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/missing-static-method.wac.result
@@ -1,7 +1,7 @@
 failed to resolve document
 
   × mismatched instantiation argument `x`
-  ╰─▶ instance is missing expected export `[static]r.foo`
+  ╰─▶ instance is missing expected function export `[static]r.foo`
    ╭─[tests/resolution/fail/missing-static-method.wac:8:23]
  7 │ 
  8 │ let i = new foo:bar { x };

--- a/crates/wac-parser/tests/resolution/fail/target-import-mismatch-resource.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-import-mismatch-resource.wac
@@ -1,0 +1,15 @@
+package test:comp targets test:comp/foo;
+
+world foo {
+    import foo: interface {
+        resource x {
+            constructor();
+        }
+    };
+}
+
+import foo2 as foo: interface {
+    resource y {
+        constructor();
+    }
+};

--- a/crates/wac-parser/tests/resolution/fail/target-import-mismatch-resource.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-import-mismatch-resource.wac.result
@@ -1,0 +1,11 @@
+failed to resolve document
+
+  × import `foo` has a mismatched type for target world `test:comp/foo`
+  ╰─▶ instance has unexpected resource export `y`
+    ╭─[tests/resolution/fail/target-import-mismatch-resource.wac:11:16]
+ 10 │ 
+ 11 │ import foo2 as foo: interface {
+    ·                ─┬─
+    ·                 ╰── mismatched type for import `foo`
+ 12 │     resource y {
+    ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-import-param-name-mismatch.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-import-param-name-mismatch.wac
@@ -1,0 +1,11 @@
+package test:comp targets test:comp/foo;
+
+world foo {
+    import foo: interface {
+        foo: func(a: string);
+    };
+}
+
+import foo2 as foo: interface {
+    foo: func(x: u32);
+};

--- a/crates/wac-parser/tests/resolution/fail/target-import-param-name-mismatch.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-import-param-name-mismatch.wac.result
@@ -1,0 +1,12 @@
+failed to resolve document
+
+  × import `foo` has a mismatched type for target world `test:comp/foo`
+  ├─▶ mismatched type for export `foo`
+  ╰─▶ expected function parameter 0 to be named `a`, found name `x`
+    ╭─[tests/resolution/fail/target-import-param-name-mismatch.wac:9:16]
+  8 │ 
+  9 │ import foo2 as foo: interface {
+    ·                ─┬─
+    ·                 ╰── mismatched type for import `foo`
+ 10 │     foo: func(x: u32);
+    ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-import-param-type-mismatch.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-import-param-type-mismatch.wac
@@ -1,0 +1,11 @@
+package test:comp targets test:comp/foo;
+
+world foo {
+    import foo: interface {
+        foo: func(a: u32);
+    };
+}
+
+import foo2 as foo: interface {
+    foo: func(a: string);
+};

--- a/crates/wac-parser/tests/resolution/fail/target-import-param-type-mismatch.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-import-param-type-mismatch.wac.result
@@ -1,0 +1,13 @@
+failed to resolve document
+
+  × import `foo` has a mismatched type for target world `test:comp/foo`
+  ├─▶ mismatched type for export `foo`
+  ├─▶ mismatched type for function parameter `a`
+  ╰─▶ expected u32, found string
+    ╭─[tests/resolution/fail/target-import-param-type-mismatch.wac:9:16]
+  8 │ 
+  9 │ import foo2 as foo: interface {
+    ·                ─┬─
+    ·                 ╰── mismatched type for import `foo`
+ 10 │     foo: func(a: string);
+    ╰────

--- a/crates/wac-parser/tests/resolution/fail/target-import-unexpected-method.wac
+++ b/crates/wac-parser/tests/resolution/fail/target-import-unexpected-method.wac
@@ -1,0 +1,16 @@
+package test:comp targets test:comp/foo;
+
+world foo {
+    import foo: interface {
+        resource x {
+            constructor();
+        }
+    };
+}
+
+import foo2 as foo: interface {
+    resource x {
+        constructor();
+        f: func(a: u32);
+    }
+};

--- a/crates/wac-parser/tests/resolution/fail/target-import-unexpected-method.wac.result
+++ b/crates/wac-parser/tests/resolution/fail/target-import-unexpected-method.wac.result
@@ -1,0 +1,11 @@
+failed to resolve document
+
+  × import `foo` has a mismatched type for target world `test:comp/foo`
+  ╰─▶ instance has unexpected function export `[method]x.f`
+    ╭─[tests/resolution/fail/target-import-unexpected-method.wac:11:16]
+ 10 │ 
+ 11 │ import foo2 as foo: interface {
+    ·                ─┬─
+    ·                 ╰── mismatched type for import `foo`
+ 12 │     resource x {
+    ╰────


### PR DESCRIPTION
This PR improves the subtype checking logic and the error messages it produces.

It fixes a bug where the `targets` check was not properly performing checks against imports, which should be contravariant.

Also fixes a warning relating to a deprecated function call; the fix is to not remove from the collection as we no longer have to since the bytes of a package are behind an `Arc`.

Additionally, fixes a bug in calculating of spans relating to expressions with postfix operations; incorrect length calculations would cause a panic when formatting errors with those spans.