### PR TITLE
Find defined type id used in remapping in `ItemKind::Type`

### DIFF
--- a/crates/wac-types/src/aggregator.rs
+++ b/crates/wac-types/src/aggregator.rs
@@ -679,8 +679,8 @@ impl TypeAggregator {
             .get(&ItemKind::Type(Type::Value(ValueType::Defined(id))))
         {
             return match kind {
-                ItemKind::Value(ValueType::Defined(id)) => *id,
-                _ => panic!("expected a defined type"),
+                ItemKind::Type(Type::Value(ValueType::Defined(id))) => *id,
+                _ => panic!("expected a defined type got {kind:?}"),
             };
         }
 


### PR DESCRIPTION
I was running into a panic `expected a defined type` where the `kind` was a `ItemKind::Type(Type::Value(ValueType::Defined(_)))`.

It seems that at the end of `remap_defined_type`, we're inserting `ItemKind::Type(Type::Value(ValueType::Defined(id)))` into the aggregated map and so we should always expect to get these defined types with a `ItemKind::Type(Type::Value(ValueType::Defined(_)))` key.

This does seem to fix the issue though I'm not sure what the consequences if any of always storing things as `ItemKind:::Type` vs. `ItemKind::Value`.
