### PR TITLE
Keep better track of already seen instances in encoder.

### DIFF
--- a/crates/wac-graph/src/encoding.rs
+++ b/crates/wac-graph/src/encoding.rs
@@ -325,6 +325,7 @@ impl<'a> TypeEncoder<'a> {
                 let index = state.current.encodable.type_count();
                 state.current.encodable.ty().instance(&ty);
                 log::debug!("instance {id} encoded to type index {index}");
+                state.current.instances.insert(id, index);
                 index
             }
             _ => panic!("expected the pushed encodable to be an instance type"),

--- a/crates/wac-graph/src/graph.rs
+++ b/crates/wac-graph/src/graph.rs
@@ -1405,11 +1405,6 @@ impl<'a> CompositionGraphEncoder<'a> {
                 },
             );
 
-            // Ensure we insert an instance index into the current scope
-            if let ItemKind::Instance(id) = kind {
-                state.current.instances.insert(id, index);
-            }
-
             let prev = encoded.insert(name, (kind.into(), index));
             assert!(prev.is_none());
         }


### PR DESCRIPTION
Before this change, the encoder would not keep track of instances that were not in the implicit instantiation args but were still deps of some other instances and thus imported.

With this change, instance tracking is moved inside of the encoder so it always knows when it encodes an instance to refer to that encoded instance if the instance is encountered again instead of re-encoding.

I'm having a hard time coming up with a test that has an instance as a dependency but is not populated in the implicit args, so marking this as a draft until I can do that. 